### PR TITLE
dbDataType's first argument should be DBIDriver

### DIFF
--- a/R/db.data.type.PrestoConnection.R
+++ b/R/db.data.type.PrestoConnection.R
@@ -7,5 +7,5 @@
 
 #' @export
 db_data_type.PrestoConnection <- function(con, fields, ...) {
-  return(sapply(fields, function(field) dbDataType(con, field)))
+  return(sapply(fields, function(field) dbDataType(Presto(), field)))
 }

--- a/R/src.translate.env.src.presto.R
+++ b/R/src.translate.env.src.presto.R
@@ -7,7 +7,6 @@
 
 #' @export
 src_translate_env.src_presto <- function(x) {
-  con <- x[['con']]
   return(dplyr::sql_variant(
     dplyr::sql_translator(.parent = dplyr::base_scalar,
       ifelse = dplyr::sql_prefix("if"),

--- a/R/src.translate.env.src.presto.R
+++ b/R/src.translate.env.src.presto.R
@@ -12,7 +12,7 @@ src_translate_env.src_presto <- function(x) {
     dplyr::sql_translator(.parent = dplyr::base_scalar,
       ifelse = dplyr::sql_prefix("if"),
       as = function(column, type) {
-        sql_type <- db_data_type(con, type)
+        sql_type <- toupper(dbDataType(Presto(), type))
         dplyr::build_sql('CAST(', column, ' AS ', dplyr::ident(sql_type), ')')
       },
       tolower = dplyr::sql_prefix("lower"),

--- a/tests/testthat/test-dplyr.integration.R
+++ b/tests/testthat/test-dplyr.integration.R
@@ -29,7 +29,7 @@ test_that('dplyr integration works', {
 
   iris_presto_summary <- iris_presto %>%
     group_by(species) %>%
-    summarise(mean_sepal_length = mean(sepal_length)) %>%
+    summarise(mean_sepal_length = mean(as(sepal_length, 0.0))) %>%
     arrange(species) %>%
     rename(Species = species) %>%
     collect %>%

--- a/tests/testthat/test-src_translate_env.R
+++ b/tests/testthat/test-src_translate_env.R
@@ -1,0 +1,70 @@
+# Copyright (c) 2015-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+context('src_translate_env')
+
+source('utilities.R')
+
+test_that('as() works', {
+  v <- src_translate_env(setup_mock_dplyr_connection()[['db']])
+  expect_equal(
+    translate_sql(as(x, 0.0), variant=v),
+    sql('CAST("x" AS "DOUBLE")')
+  )
+
+  expect_equal(
+    translate_sql_q(list(substitute(as(x, l), list(l=list()))), variant=v),
+    sql('CAST("x" AS "ARRAY<VARCHAR>")')
+  )
+
+
+  substituted.expression <- substitute(as(x, l), list(l=Sys.Date()))
+  expect_equal(
+    translate_sql_q(list(substituted.expression), variant=v),
+    sql('CAST("x" AS "DATE")')
+  )
+
+  # Hacky dummy table so that we can test substitution
+  t <- tbl(s, from=sql('SELECT 1'), vars=list(as.name('a')))
+
+  l <- list(a=1L)
+  expect_equal(
+    translate_sql(as(x, l), tbl=t),
+    sql('CAST("x" AS "MAP<VARCHAR, BIGINT>")')
+  )
+
+  expect_equal(
+    translate_sql(as(x, local(list(a=Sys.time()))), tbl=t),
+    sql('CAST("x" AS "MAP<VARCHAR, TIMESTAMP>")')
+  )
+
+  r <- as.raw(0)
+  p <- as.POSIXct('2001-02-03 04:05:06', tz='Europe/Istanbul')
+  query <- as.character(
+    (
+      t 
+      %>% transmute(
+        b=as(a, r),
+        c=as(a, p),
+        d=as(a, TRUE)
+      )
+    )[['query']][['sql']]
+  )
+  expect_more_than(
+    length(grep(
+      paste0(
+        '^SELECT ',
+        'CAST\\("a" AS "VARBINARY"\\) AS "b", ' ,
+        'CAST\\("a" AS "TIMESTAMP WITH TIME ZONE"\\) AS "c", ',
+        'CAST\\("a" AS "BOOLEAN"\\) AS "d"\n',
+        'FROM \\(SELECT 1\\) AS "_W\\d+"$'),
+      query
+      )
+    ),
+    0
+  )
+})


### PR DESCRIPTION
With this I also switched to calling dbDataType directly instead of using db_data_type. Using real objects is rather tricky with the 'fields' argument for that function.
It's actually quite easy to misuse since list() is a valid argument to dbDataType for the PrestoDriver.
So we might want to disable/remove db_data_type until there is a more significant need.

Note that this PR stacks on top of #26.