### PR TITLE
Use environments to lookup data types

### DIFF
--- a/R/dbDataType.R
+++ b/R/dbDataType.R
@@ -53,6 +53,9 @@ colnames(.R.to.presto) <- c('presto.type', 'R.type')
 
 .R.to.presto.env <- new.env(hash=TRUE, size=NROW(.R.to.presto))
 for (i in 1:NROW(.R.to.presto)) {
+  if (is.na(.R.to.presto[i, 'R.type'])) {
+    next
+  }
   assign(
     .R.to.presto[i, 'R.type'],
     value=.R.to.presto[i, 'presto.type'],


### PR DESCRIPTION
All tests passed. The function now looks to be about 30% faster, here is the benchmarking code
```
> types <- rep(c(
+   'logical',
+   'integer',
+   'double',
+   'character',
+   'raw',
+   'Date',
+   'POSIXct_no_time_zone',
+   'POSIXct_with_time_zone',
+   'list_unnamed',
+   'list_named',
+   'factor',
+   'ordered',
+   'NULL'
+ ), 10)
>
> system('git checkout master')
Switched to branch 'master'
Your branch is up-to-date with 'origin/master'.
> load_all()
Loading RPresto
> drv <- RPresto::Presto()
> microbenchmark(lapply(types, function(t) dbDataType(drv, t)))
Unit: milliseconds
                                          expr      min       lq     mean   median       uq      max neval
 lapply(types, function(t) dbDataType(drv, t)) 9.545974 9.645558 10.05135 9.783449 10.12167 13.82781   100
>
> system('git checkout improve-perf')
Switched to branch 'improve-perf'
> load_all()
Loading RPresto
> drv <- RPresto::Presto()
> microbenchmark(lapply(types, function(t) dbDataType(drv, t)))
Unit: milliseconds
                                          expr      min      lq     mean   median      uq      max neval
 lapply(types, function(t) dbDataType(drv, t)) 6.378918 6.58473 6.884432 6.683375 7.01989 10.38293   100
```

I also tried benchmarking actually hitting the presto server but there is a lot of noise and it was hard to see consistent results. That said, it did look faster in most of the queries I ran.