### PR TITLE
Use `dplyr::bind_rows` if available.

### DIFF
--- a/R/dbFetch.R
+++ b/R/dbFetch.R
@@ -73,7 +73,11 @@ NULL
     # Preserve attributes for empty data frames
     return(rv[[1]])
   } else {
-    return(do.call('rbind', rv))
+    if (requireNamespace('dplyr', quietly=TRUE)) {
+      return(as.data.frame(dplyr::bind_rows(rv)))
+    } else {
+      return(do.call('rbind', rv))
+    }
   }
 }
 


### PR DESCRIPTION
This is much faster than using `do.call('rbind', ...)` for large sets of data.