### PR TITLE
Handle non standard numerics

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RPresto
 Title: DBI connector to Presto
-Version: 1.1.0
+Version: 1.1.1
 Authors@R: c(
     person('Onur Ismail', 'Filiz', , 'onur@fb.com', role=c('aut', 'cre')),
     person('Sergey', 'Goder', , 'sgoder@fb.com', role='aut'),

--- a/R/json.tabular.to.data.frame.R
+++ b/R/json.tabular.to.data.frame.R
@@ -128,6 +128,13 @@ NULL
     }
   }
 
+  for (j in which(column.types %in% 'numeric')) {
+    rv[[j]] <- replace(rv[[j]], rv[[j]] == 'Infinity', Inf)
+    rv[[j]] <- replace(rv[[j]], rv[[j]] == '-Infinity', -Inf)
+    rv[[j]] <- replace(rv[[j]], rv[[j]] == 'NaN', NaN)
+    rv[[j]] <- as.numeric(rv[[j]])
+  }
+
   for (j in which(column.types %in% 'Date')) {
     rv[[j]] <- as.Date(rv[[j]])
   }

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -28,7 +28,7 @@ test_that("Connections handle port argument correctly", {
 
 test_that('Integration tests work', {
   conn <- setup_live_connection()
-  
+
   expect_that(conn, is_a("PrestoConnection"))
 
   sql <- paste('SELECT * FROM', iris.sql(), 'LIMIT 5')

--- a/tests/testthat/test-json_tabular_to_data_frame.R
+++ b/tests/testthat/test-json_tabular_to_data_frame.R
@@ -212,3 +212,33 @@ test_that('NAs are handled correctly', {
   expect_equal_data_frame(r, e.reversed)
 })
 
+test_that('Inf, -Inf and NaN are handled correctly', {
+  expect_equal_data_frame(
+    .json.tabular.to.data.frame(
+      list(list(A='Infinity', B='-Infinity', C='NaN')),
+      c('numeric', 'numeric', 'numeric')
+    ),
+    data.frame(A=Inf, B=-Inf, C=NaN)
+  )
+
+  expect_equal_data_frame(
+    .json.tabular.to.data.frame(
+      list(list(A='Infinity', B='-Infinity', C='NaN')),
+      c('character', 'character', 'character')
+    ),
+    data.frame(A='Infinity', B='-Infinity', C='NaN')
+  )
+
+  expect_equal_data_frame(
+    .json.tabular.to.data.frame(
+      list(
+        list(A=1.0, B=1.0, C=1.0),
+        list(A='Infinity', B='-Infinity', C='NaN'),
+        list(A=1.0, B=1.0, C=1.0)
+      ),
+      c('numeric', 'numeric', 'numeric')
+    ),
+    data.frame(A=c(1.0, Inf, 1.0), B=c(1.0, -Inf, 1.0), C=c(1.0, NaN, 1.0))
+  )
+
+})


### PR DESCRIPTION
Specifically we need to special case the Inf and NaN values coming from Presto
as they are returned as strings. This causes R to fail if you have dplyr
installed because `bind_rows` will fail if columns have different types in the
data frames it is trying to combine. Even if you don't have dplyr installed this
will cause your numeric column to become a character because of R's implicit
conversion.

This is rebased on #39 to make the tests pass, we should merge that first.