### PR TITLE
Add subscripting support for arrays and maps

### DIFF
--- a/R/src.translate.env.src.presto.R
+++ b/R/src.translate.env.src.presto.R
@@ -5,6 +5,10 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
+.subscript <- function(struct, index) {
+  dplyr::build_sql(struct, '[', index, ']')
+}
+
 #' @export
 src_translate_env.src_presto <- function(x) {
   return(dplyr::sql_variant(
@@ -14,6 +18,9 @@ src_translate_env.src_presto <- function(x) {
         sql_type <- toupper(dbDataType(Presto(), type))
         dplyr::build_sql('CAST(', column, ' AS ', dplyr::ident(sql_type), ')')
       },
+      `[` = .subscript,
+      `[[` = .subscript,
+      length = dplyr::sql_prefix("cardinality"),
       tolower = dplyr::sql_prefix("lower"),
       toupper = dplyr::sql_prefix("upper"),
       pmax = dplyr::sql_prefix("greatest"),

--- a/tests/testthat/test-src_translate_env.R
+++ b/tests/testthat/test-src_translate_env.R
@@ -69,3 +69,26 @@ test_that('as() works', {
     0
   )
 })
+
+test_that('subscript works', {
+  v <- src_translate_env(setup_mock_dplyr_connection()[['db']])
+  expect_equal(
+    translate_sql(x[0L], variant=v),
+    sql('"x"[0]')
+  )
+
+  expect_equal(
+    translate_sql(m['item'], variant=v),
+    sql('"m"[\'item\']')
+  )
+
+  expect_equal(
+    translate_sql(x[[0L]], variant=v),
+    sql('"x"[0]')
+  )
+
+  expect_equal(
+    translate_sql(m[['item']], variant=v),
+    sql('"m"[\'item\']')
+  )
+})


### PR DESCRIPTION
Note that these are sort of difficult to use since they need to be
wrapped with `remote()` for most calls.

There is also `getElement` that I could add to the mix that could be
used directly.

On the other hand, I don't want to over-implement.
We will need a separate subscripting operator when we add support for
rows, and I was thinking maybe we could use `getElement` for that
specifically.

Another alternative is to use `[` for arrays and maps, and
use `[[` for rows. But then we sort of break the parallel between maps
and lists.

Any advice?

Test Plan:

```
library('dplyr')
library('testthat')
devtools::load_all('~/local/repositories/RPresto')
devtools::test('~/local/repositories/RPresto', 'src_translate_env')
```
