### PR TITLE
Fix locale and encoding handling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,8 @@ Imports:
     DBI (>= 0.3.0),
     httr (>= 0.6),
     RCurl,
-    jsonlite
+    jsonlite,
+    stringi
 Suggests:
     testthat,
     dplyr (>= 0.4.1)

--- a/R/dbDataType.R
+++ b/R/dbDataType.R
@@ -124,7 +124,10 @@ for (i in seq_along(.non.complex.types)) {
   if (is.na(rv)) {
     rv <- 'varchar'
   }
-  return(toupper(rv))
+  # We need to explicitly specify the locale for the upper transformation.
+  # For certain locales like tr_TR, the uppercase for 'i' is 'İ'
+  # so toupper('bigint') does not give the expected result
+  return(stringi::stri_trans_toupper(rv, 'en_US.UTF-8'))
 }
 
 #' Return the corresponding presto data type for the given R \code{object}

--- a/R/dbSendQuery.R
+++ b/R/dbSendQuery.R
@@ -30,7 +30,7 @@ NULL
   headers <- .request.headers(conn)
   while (status == 503) {
     wait()
-    post.response <- httr::POST(url, body=statement, headers)
+    post.response <- httr::POST(url, body=enc2utf8(statement), headers)
     status <- httr::status_code(post.response)
   }
   check.status.code(post.response)

--- a/R/src.translate.env.src.presto.R
+++ b/R/src.translate.env.src.presto.R
@@ -11,7 +11,10 @@ src_translate_env.src_presto <- function(x) {
     dplyr::sql_translator(.parent = dplyr::base_scalar,
       ifelse = dplyr::sql_prefix("if"),
       as = function(column, type) {
-        sql_type <- toupper(dbDataType(Presto(), type))
+        sql_type <- stringi::stri_trans_toupper(
+          dbDataType(Presto(), type),
+          'en_US.UTF-8'
+        )
         dplyr::build_sql('CAST(', column, ' AS ', dplyr::ident(sql_type), ')')
       },
       tolower = dplyr::sql_prefix("lower"),

--- a/tests/testthat/test-dbDataType.R
+++ b/tests/testthat/test-dbDataType.R
@@ -7,8 +7,10 @@
 
 context('dbDataType')
 
-drv <- RPresto::Presto()
-test_that('presto simple types are correct', {
+with_locale(test.locale(), test_that)('presto simple types are correct', {
+
+    drv <- RPresto::Presto()
+
     expect_equal(dbDataType(drv, NULL), 'VARCHAR')
     expect_equal(dbDataType(drv, TRUE), 'BOOLEAN')
     expect_equal(dbDataType(drv, 1L), 'BIGINT')
@@ -33,6 +35,8 @@ test_that('presto simple types are correct', {
 })
 
 test_that('conversion to array is correct', {
+    drv <- RPresto::Presto()
+
     expect_equal(dbDataType(drv, list()), 'ARRAY<VARCHAR>')
     expect_equal(dbDataType(drv, list(list())), 'ARRAY<ARRAY<VARCHAR>>')
     expect_equal(dbDataType(drv,
@@ -54,6 +58,8 @@ test_that('conversion to array is correct', {
 })
 
 test_that('conversion to map is correct', {
+    drv <- RPresto::Presto()
+
     l <- structure(list(), names=character(0))
     expect_equal(dbDataType(drv, l), 'MAP<VARCHAR, VARCHAR>')
     expect_equal(

--- a/tests/testthat/test-dbFetch.R
+++ b/tests/testthat/test-dbFetch.R
@@ -201,8 +201,7 @@ test_that('dbFetch works with mock', {
   )
 })
 
-test_that('dbFetch rbind works correctly', {
-
+with_locale(test.locale(), test_that)('dbFetch rbind works correctly', {
   conn <- setup_mock_connection()
 
   with_mock(

--- a/tests/testthat/test-extract.data.R
+++ b/tests/testthat/test-extract.data.R
@@ -11,7 +11,8 @@ source('utilities.R')
 
 .extract.data <- RPresto:::.extract.data
 
-test_that('extract.data works', {
+with_locale(test.locale(), test_that)('extract.data works', {
+
   expect_equal(.extract.data(list()), data.frame())
 
   content <- RPresto:::response.to.content(

--- a/tests/testthat/test-get.state.R
+++ b/tests/testthat/test-get.state.R
@@ -9,9 +9,12 @@ context('get.state')
 
 source('utilities.R')
 
-get.state <- RPresto:::get.state
 
-test_that('get.state works', {
+with_locale(test.locale(), test_that)(
+  'get.state works', {
+
+  get.state <- RPresto:::get.state
+
   content <- RPresto:::response.to.content(
     mock_httr_response(
       'dummy_url',

--- a/tests/testthat/test-json_tabular_to_data_frame.R
+++ b/tests/testthat/test-json_tabular_to_data_frame.R
@@ -70,7 +70,8 @@ test_that('edge cases are handled correctly', {
     expect_equal_data_frame(r, data.frame(rep(NA, 3))[, FALSE, drop=FALSE])
 })
 
-test_that('regular data is converted correctly', {
+with_locale(test.locale(), test_that)('regular data is converted correctly', {
+
   input <- list(
     list(
       TRUE,
@@ -81,7 +82,7 @@ test_that('regular data is converted correctly', {
       '2015-03-01',
       '2015-03-01 12:00:00',
       '2015-03-01 12:00:00 UTC',
-      'ıİ',
+      iconv('\xFD\xDD\xD6\xF0', localeToCharset(test.locale()), 'UTF-8'),
       list(1, 2),
       list(a=1, b=2)
     ),
@@ -94,7 +95,7 @@ test_that('regular data is converted correctly', {
       '2015-03-02',
       '2015-03-02 12:00:00.321',
       '2015-03-02 12:00:00.321 UTC',
-      'ö',
+      { x <- '\xE1\xBD\xA0\x32'; Encoding(x) <- 'UTF-8'; x},
       list(),
       structure(list(), names=character(0))
     )
@@ -112,9 +113,20 @@ test_that('regular data is converted correctly', {
 
   expect_equal_data_frame(r, e, label='unnamed items')
 
+  Sys.setlocale('LC_CTYPE', 'fr_FR.iso8859-15@euro')
+  # This will fail because data.frame.with.all.classes() returns
+  # the first item of '<odd_name>' without an explicit encoding.
+  # However the data given to json.tabular.to.data.frame is reencoded
+  # to utf-8 from the test encoding which is not iso8859-15.
+  # Therefore, the comparison is effectively between:
+  # iconv('\xFD...', 'iso8859-15', 'utf8')
+  # iconv('\xFD...', '<test_encoding>', 'utf8')
+  expect_false(isTRUE(all.equal(r, e)))
+
   input.with.names <- lapply(input,
     function(x) { names(x) <- column.names; return(x) }
   )
+  Sys.setlocale('LC_CTYPE', test.locale())
   r <- .json.tabular.to.data.frame(input.with.names, column.classes)
   expect_equal_data_frame(r, e, label='auto parse names')
 })

--- a/tests/testthat/test-response.to.content.R
+++ b/tests/testthat/test-response.to.content.R
@@ -9,9 +9,8 @@ context('response.to.content')
 
 source('utilities.R')
 
-response.to.content <- RPresto:::response.to.content
-
-test_that('response.to.content works', {
+with_locale(test.locale(), test_that)('response.to.content works', {
+  response.to.content <- RPresto:::response.to.content
 
   response <- mock_httr_response(
       'dummy_url',
@@ -21,7 +20,7 @@ test_that('response.to.content works', {
       data=data.frame(
         l=TRUE,
         m=NA_integer_,
-        n='öğışüçÖĞİŞÜÇ',
+        n={ x <- 'öğışüçÖĞİŞÜÇ'; Encoding(x) <- 'UTF-8'; x },
         stringsAsFactors=FALSE
       )
   )[['response']]
@@ -61,7 +60,11 @@ test_that('response.to.content works', {
         )
       ),
       data=list(
-        list(TRUE, "NA", 'öğışüçÖĞİŞÜÇ')
+        list(
+          TRUE,
+          "NA",
+          { x <- 'öğışüçÖĞİŞÜÇ'; Encoding(x) <- 'UTF-8'; x }
+        )
       )
     )
   )

--- a/tests/testthat/test-src_translate_env.R
+++ b/tests/testthat/test-src_translate_env.R
@@ -9,7 +9,8 @@ context('src_translate_env')
 
 source('utilities.R')
 
-test_that('as() works', {
+with_locale(test.locale(), test_that)('as() works', {
+
   v <- src_translate_env(setup_mock_dplyr_connection()[['db']])
   expect_equal(
     translate_sql(as(x, 0.0), variant=v),
@@ -30,7 +31,7 @@ test_that('as() works', {
 
   # Hacky dummy table so that we can test substitution
   s <- setup_live_dplyr_connection()[['db']]
-  t <- tbl(s, from=sql('SELECT 1'), vars=list(as.name('a')))
+  t <- tbl(s, from=sql('SELECT 1'), vars=list(as.name('x')))
 
   l <- list(a=1L)
   expect_equal(


### PR DESCRIPTION
As #25 identified, some tests were failing when locale was not en_US.utf-8.

The issues were mostly around encodings of strings in the test cases.

One bug I identified was the use of toupper. With a Turkish locale, the uppercase of 'i' is 'İ' for instance.
To work around, we use 'stringi', which is already a dependency of 'httr' via 'stringr'.

Fixes #25.

For testing:

    Sys.setlocale('LC_CTYPE', 'C')
    library('dplyr'); library('DBI'); devtools::load_all('~/local/repositories/RPresto'); devtools::test('~/local/repositories/RPresto')

    Sys.setlocale('LC_CTYPE', 'en_US.utf-8')
    library('dplyr'); library('DBI'); devtools::load_all('~/local/repositories/RPresto'); devtools::test('~/local/repositories/RPresto')