### PR TITLE
Relax error checking for 403 HTTP error

### DIFF
--- a/tests/testthat/test-check.status.code.R
+++ b/tests/testthat/test-check.status.code.R
@@ -38,6 +38,6 @@ test_that('check.status.code works', {
   )
   expect_error(
     check.status.code(response),
-    'client error: \\(403\\) Forbidden'
+    '403'
   )
 })


### PR DESCRIPTION
This was the error we were getting:
```
> test('/data/users/sgoder/RPresto', filter='check.status.code')
Loading RPresto
Testing RPresto
check.status.code : ..1

1. Failure (at test-check.status.code.R#39): check.status.code works ----------------------------
check.status.code(response) does not match 'client error: \\(403\\) Forbidden'. Actual value: "Error in check.status.code(response) : Forbidden (HTTP 403).\n"
```

Really we just care if there is a 403 or not so lets just check for that part.