### PR TITLE
Fix Inf/NaN test

### DIFF
--- a/tests/testthat/test-json_tabular_to_data_frame.R
+++ b/tests/testthat/test-json_tabular_to_data_frame.R
@@ -238,7 +238,7 @@ test_that('Inf, -Inf and NaN are handled correctly', {
       list(list(A='Infinity', B='-Infinity', C='NaN')),
       c('character', 'character', 'character')
     ),
-    data.frame(A='Infinity', B='-Infinity', C='NaN')
+    data.frame(A='Infinity', B='-Infinity', C='NaN', stringsAsFactors=FALSE)
   )
 
   expect_equal_data_frame(


### PR DESCRIPTION
We are getting this error because of the implicit conversion to factors

```
> test('/data/users/sgoder/RPresto', filter='json')
Loading RPresto
Testing RPresto
.json.tabular.to.data.frame : .............................1.

1. Failure (at utilities.R#28): Inf, -Inf and NaN are handled correctly --------
r not equal to e
Component "A": Modes: character, numeric
Component "A": Attributes: < target is NULL, current is list >
Component "A": target is character, current is factor
Component "B": Modes: character, numeric
Component "B": Attributes: < target is NULL, current is list >
Component "B": target is character, current is factor
Component "C": Modes: character, numeric
Component "C": Attributes: < target is NULL, current is list >
Component "C": target is character, current is factor
```

I must have had the option set to `FALSE` when testing that commit.