### PR TITLE
Add warning for integer columns being corrupted by lacking 64-bit integer support

### DIFF
--- a/R/json.tabular.to.data.frame.R
+++ b/R/json.tabular.to.data.frame.R
@@ -139,6 +139,20 @@ NULL
     rv[[j]] <- as.Date(rv[[j]])
   }
 
+  broken.integer.columns <- character(0)
+  for (j in which(column.types %in% 'integer')) {
+    if (!is.integer(rv[[j]])) {
+      broken.integer.columns <- c(broken.integer.columns, j)
+    }
+  }
+  if (length(broken.integer.columns) > 0) {
+    warning('integer columns [', paste(broken.integer.columns, collapse=', '),
+      '] are cast to double since R does not have full support for ',
+      '64-bit integers. This might result in precision loss. ',
+      'Cast them to VARCHAR\'s in presto if you need exact values.')
+  }
+
+
   for (j in which(column.types %in% 'POSIXct_no_time_zone')) {
     rv[[j]] <- as.POSIXct(rv[[j]])
   }

--- a/tests/testthat/test-bigint_handling.R
+++ b/tests/testthat/test-bigint_handling.R
@@ -1,0 +1,28 @@
+# Copyright (c) 2015-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+context('bigint handling')
+
+source('utilities.R')
+
+test_that('Non 32-bit integers give warning', {
+  conn <- setup_live_connection()
+
+  expect_warning(
+    dbGetQuery(conn, "SELECT 2147483648 AS a, 3 AS b"),
+    'columns \\[1\\] are cast to double'
+  )
+  expect_warning(
+    dbGetQuery(conn, "SELECT -3 AS d, -2147483649 AS c"),
+    'columns \\[2\\] are cast to double'
+  )
+  rv <- suppressWarnings(dbGetQuery(conn, "SELECT 9223372036854775807 AS number"))
+  expect_false(as.character(rv[['number']]) == "9223372036854775807")
+
+  rv <- dbGetQuery(conn, "SELECT CAST(9223372036854775807 AS VARCHAR) AS string")
+  expect_equal(rv[['string']], "9223372036854775807")
+})


### PR DESCRIPTION
Presto BIGINT columns support 64-bit integers, whereas R is still
lacking full support for them. R silently casts any such value to a
double, which leads to loss of precision and is impossible to recover
afterwards.

jsonlite solves this by utilizing the bit64 package. That approach has
lots of caveats though, so we need to investigate more to see if we can
do the same.