### PR TITLE
Support zero row multiple column results 

### DIFF
--- a/R/extract.data.R
+++ b/R/extract.data.R
@@ -9,8 +9,9 @@
 NULL
 
 .extract.data <- function(response.content, timezone) {
-  if (is.null(response.content[['data']])) {
-    return(data.frame())
+  data.list <- response.content[['data']]
+  if (is.null(data.list)) {
+    data.list <- list()
   }
   column.info <- .json.tabular.to.data.frame(
     response.content[['columns']],
@@ -25,10 +26,9 @@ NULL
     ''
   )
   r.types <- with(.presto.to.R, R.type[match(presto.types, presto.type)])
-  rv <- .json.tabular.to.data.frame(
-    response.content[['data']],
-    r.types,
-    timezone=timezone)
-  colnames(rv) <- column.info[['name']]
+  rv <- .json.tabular.to.data.frame(data.list, r.types, timezone=timezone)
+  if (!is.null(column.info[['name']])) {
+    colnames(rv) <- column.info[['name']]
+  }
   return(rv)
 }

--- a/R/json.tabular.to.data.frame.R
+++ b/R/json.tabular.to.data.frame.R
@@ -152,7 +152,6 @@ NULL
       'Cast them to VARCHAR\'s in presto if you need exact values.')
   }
 
-
   for (j in which(column.types %in% 'POSIXct_no_time_zone')) {
     rv[[j]] <- as.POSIXct(rv[[j]], tz=timezone)
   }
@@ -178,7 +177,12 @@ NULL
   # Unfortunately, even with rv[[j]][[i]] indexing, R makes a copy of
   # the data.frame and as such is *very* slow.
   attr(rv, 'class') <- 'data.frame'
-  attr(rv, 'row.names') <- c(NA, -1 * row.count)
+  if (row.count > 0) {
+    row.names <- c(NA, -1 * row.count)
+  } else {
+    row.names <- integer(0)
+  }
+  attr(rv, 'row.names') <- row.names
   colnames(rv) <- column.names
   return(rv)
 }

--- a/tests/testthat/test-extract.data.R
+++ b/tests/testthat/test-extract.data.R
@@ -13,7 +13,48 @@ source('utilities.R')
 
 with_locale(test.locale(), test_that)('extract.data works', {
 
-  expect_equal(.extract.data(list()), data.frame())
+  response <- mock_httr_response(
+      'dummy_url',
+      state='dummy_state',
+      status_code=0,
+      data=data.frame()
+    )[['response']]
+  content <- RPresto:::response.to.content(response)
+
+  dt <- .extract.data(content, timezone=test.timezone())
+  expect_equal(
+    .extract.data(content, timezone=test.timezone()),
+    data.frame(),
+    label='zero row, zero columns'
+  )
+
+  # We need to remove the tzone attribute otherwise the mocker treats it
+  # as a timestamp with time zone column
+  d <- data.frame.with.all.classes()
+  attr(d[['POSIXct_no_time_zone']], 'tzone') <- NULL
+
+  # We cannot directly send the zero row version of 'd', since then type
+  # inference for list() columns do not work. So we send the full data,
+  # then set the list form to NULL in the content
+  response <- mock_httr_response(
+      'dummy_url',
+      state='dummy_state',
+      status_code=0,
+      data=d,
+    )[['response']]
+  content <- RPresto:::response.to.content(response)
+  content[['data']] <- NULL
+
+  # We need to remove the timezone from the column since without any
+  # data json.tabular.to.data.frame has no way of finding it
+  ev <- data.frame.with.all.classes()[FALSE, ]
+  attr(ev[['POSIXct_with_time_zone']], 'tzone') <- NA_character_
+
+  expect_equal_data_frame(
+    .extract.data(content, timezone=test.timezone()),
+    ev,
+    label='Zero row, multiple columns'
+  )
 
   content <- RPresto:::response.to.content(
     mock_httr_response(

--- a/tests/testthat/test-json_tabular_to_data_frame.R
+++ b/tests/testthat/test-json_tabular_to_data_frame.R
@@ -141,6 +141,7 @@ with_locale(test.locale(), test_that)('regular data is converted correctly', {
   input.with.names <- lapply(input,
     function(x) { names(x) <- column.names; return(x) }
   )
+  Sys.setlocale('LC_CTYPE', test.locale())
   r <- .json.tabular.to.data.frame(
     input.with.names,
     column.classes,

--- a/tests/testthat/utilities.R
+++ b/tests/testthat/utilities.R
@@ -39,6 +39,19 @@ expect_equal_data_frame <- function(r, e, ...) {
 
 test.timezone <- function() { return('Asia/Kathmandu') }
 
+test.locale <- function() { return('tr_TR.iso8859-9') }
+
+with_locale <- function(locale, f) {
+  wrapped <- function(...) {
+    old.locale <- Sys.getlocale('LC_CTYPE')
+    Sys.setlocale('LC_CTYPE', locale)
+    on.exit(Sys.setlocale('LC_CTYPE', old.locale), add=TRUE)
+    f(...)
+  }
+  return(wrapped)
+}
+
+
 data.frame.with.all.classes <- function(row.indices) {
   old.locale <- Sys.getlocale('LC_CTYPE')
   Sys.setlocale('LC_CTYPE', test.locale())

--- a/tests/testthat/utilities.R
+++ b/tests/testthat/utilities.R
@@ -87,6 +87,58 @@ data.frame.with.all.classes <- function(row.indices) {
   return(e)
 }
 
+data.to.list <- function(data) {
+  # Change POSIXct representation, otherwise microseconds
+  # are chopped off in toJSON
+  old.digits.secs <- options('digits.secs'=3)
+  on.exit(options(old.digits.secs), add=TRUE)
+
+  presto.types <- lapply(data, function(l) {
+    drv <- RPresto::Presto()
+    if (is.list(l)) {
+      rs.class <- data.class(l[[1]])
+      if (rs.class == 'raw') {
+        rv <- 'varbinary'
+      } else if (rs.class == 'list') {
+        rv <- ifelse(is.null(names(l[[1]])), 'array', 'map')
+      } else {
+        stop('Unsupported mock data type: ', rs.class)
+      }
+    } else {
+      rv <- dbDataType(RPresto::Presto(), l)
+    }
+    return(rv)
+  })
+
+  column.data <- list()
+  for (i in seq_along(presto.types)) {
+    presto.type <- stringi::stri_trans_tolower(
+      presto.types[[i]],
+      'en_US.UTF-8'
+    )
+    column.data[[i]] <- list(
+      name=jsonlite::unbox(colnames(data)[i]),
+      type=jsonlite::unbox(presto.type),
+      typeSignature=list(
+        rawType=jsonlite::unbox(presto.type),
+        typeArguments=list(),
+        literalArguments=list()
+      )
+    )
+    if (presto.type == 'timestamp with time zone') {
+      # toJSON ignores the timezone attribute
+      data[[i]] <- paste(data[[i]], attr(data[[i]], 'tzone'))
+    } else if (presto.type %in% c('array', 'map')) {
+      # Lists need to be unboxed
+      data[[i]] <- lapply( # Apply to each row
+        data[[i]],
+        function(l) lapply(l, jsonlite::unbox) # Apply to each item
+      )
+    }
+  }
+  return(list(column.data=column.data, data=data))
+}
+
 mock_httr_response <- function(
   url,
   status_code,
@@ -114,55 +166,15 @@ mock_httr_response <- function(
   }
 
   if (!missing(data)) {
-    presto.types <- lapply(data, function(l) {
-      drv <- RPresto::Presto()
-      if (is.list(l)) {
-        rs.class <- data.class(l[[1]])
-        if (rs.class == 'raw') {
-          rv <- 'varbinary'
-        } else if (rs.class == 'list') {
-          rv <- ifelse(is.null(names(l[[1]])), 'array', 'map')
-        } else {
-          stop('Unsupported mock data type: ', rs.class)
-        }
-      } else {
-        rv <- dbDataType(RPresto::Presto(), l)
-      }
-      return(rv)
-    })
-
-    # Change POSIXct representation, otherwise microseconds
-    # are chopped off in toJSON
-    old.digits.secs <- options('digits.secs'=3)
-    on.exit(options(old.digits.secs), add=TRUE)
-    content[['columns']] <- list()
-    for (i in seq_along(presto.types)) {
-      presto.type <- stringi::stri_trans_tolower(
-        presto.types[[i]],
-        'en_US.UTF-8'
-      )
-      content[['columns']][[i]] <- list(
-        name=jsonlite::unbox(colnames(data)[i]),
-        type=jsonlite::unbox(presto.type),
-        typeSignature=list(
-          rawType=jsonlite::unbox(presto.type),
-          typeArguments=list(),
-          literalArguments=list()
-        )
-      )
-      if (presto.type == 'timestamp with time zone') {
-        # toJSON ignores the timezone attribute
-        data[[i]] <- paste(data[[i]], attr(data[[i]], 'tzone'))
-      } else if (presto.type %in% c('array', 'map')) {
-        # Lists need to be unboxed
-        data[[i]] <- lapply( # Apply to each row
-          data[[i]],
-          function(l) lapply(l, jsonlite::unbox) # Apply to each item
-        )
-      }
-    }
-    content[['data']] <- data
+    content.info <- data.to.list(data)
+    content[['columns']] <- content.info[['column.data']]
+    content[['data']] <- content.info[['data']]
   }
+
+  # Change POSIXct representation, otherwise microseconds
+  # are chopped off in toJSON
+  old.digits.secs <- options('digits.secs'=3)
+  on.exit(options(old.digits.secs), add=TRUE)
 
   rv <- list(
     url=url,


### PR DESCRIPTION
We were previously returning zero columns, but this breaks with things
like `SHOW PARTITIONS FROM table LIMIT 0` to find partition columns.
