### PR TITLE
Robustness fixes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # RPresto 1.2.0.9000
 
+- Handle responses with no column information (fixes #49)
+- Add retries for GET and POST responses with error status codes
+- Skip test cases for ones that need locale modification if we cannot set the locale for the OS.
+
 # RPresto 1.2.0
 
 - Add a `session.timezone` parameter to `dbConnect` and `src_presto` which

--- a/R/dbFetch.R
+++ b/R/dbFetch.R
@@ -12,7 +12,9 @@ NULL
 .fetch.uri.with.retries <- function(uri, num.retry=3) {
   get.response <- tryCatch({
       response <- httr::GET(uri)
-      if (httr::status_code(response) >= 400) {
+      if (httr::http_error(as.integer(httr::status_code(response)))) {
+        # stop_for_status also fails for 300 <= status < 400
+        # so we add the http_error check which fails only for >= 400.
         httr::stop_for_status(response)
       }
       response

--- a/R/dbFetch.R
+++ b/R/dbFetch.R
@@ -11,7 +11,11 @@ NULL
 
 .fetch.uri.with.retries <- function(uri, num.retry=3) {
   get.response <- tryCatch({
-      httr::GET(uri)
+      response <- httr::GET(uri)
+      if (httr::status_code(response) >= 400) {
+        httr::stop_for_status(response)
+      }
+      response
     },
     error=function (e) {
       if (num.retry == 0) {

--- a/R/dbSendQuery.R
+++ b/R/dbSendQuery.R
@@ -27,14 +27,14 @@ NULL
 
 .dbSendQuery <- function(conn, statement, ...) {
   url <- paste0(conn@host, ':', conn@port, '/v1/statement')
-  status <- 503
+  status <- 503L
   retries <- 3
   headers <- .request.headers(conn)
-  while (status == 503 || (retries > 0 && status >= 400)) {
+  while (status == 503L || (retries > 0 && httr::http_error(status))) {
     wait()
     post.response <- httr::POST(url, body=enc2utf8(statement), headers)
-    status <- httr::status_code(post.response)
-    if (status >= 400 && status != 503) {
+    status <- as.integer(httr::status_code(post.response))
+    if (httr::http_error(status) && status != 503L) {
       retries <- retries - 1
     }
   }

--- a/R/extract.data.R
+++ b/R/extract.data.R
@@ -13,8 +13,12 @@ NULL
   if (is.null(data.list)) {
     data.list <- list()
   }
+  column.list <- response.content[['columns']]
+  if (is.null(column.list)) {
+    column.list <- list()
+  }
   column.info <- .json.tabular.to.data.frame(
-    response.content[['columns']],
+    column.list,
     # name, type, typeSignature
     c('character', 'character', 'list_named')
   )

--- a/R/utility_functions.R
+++ b/R/utility_functions.R
@@ -12,7 +12,7 @@ check.status.code <- function(response) {
     if (is.null(text.content) || !nzchar(text.content)) {
       httr::stop_for_status(status)
     }
-    stop(text.content)
+    stop('Received error response (HTTP ', status, '): ', text.content)
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,15 @@ for running interactive analytic queries.
 
 ## Installation
 
-RPresto is not yet released on CRAN. You can install the github version via
+RPresto is both on [CRAN](https://cran.r-project.org/web/packages/RPresto/)
+and [github](https://github.com/prestodb/RPresto).
+For the CRAN version, you can use
+
+```R
+install.packages('RPresto')
+```
+
+You can install the github development version via
 
 ```R
 devtools::install_github('prestodb/RPresto')

--- a/tests/testthat/test-dbFetch.R
+++ b/tests/testthat/test-dbFetch.R
@@ -105,6 +105,7 @@ test_that('dbFetch works with mock', {
         state=''
       )
     ),
+    `httr::handle_reset`=function(...) return(),
     {
       result <- dbSendQuery(conn, "SELECT n FROM (VALUES (1), (2)) AS t (n)")
       expect_error(
@@ -133,7 +134,9 @@ test_that('dbFetch works with mock', {
       result <- dbSendQuery(conn, 'SELECT 2')
       expect_error(
         dbFetch(result), 
-        '^Error in check\\.status\\.code\\(get.response\\)'
+        paste0('^Error in ".fetch.single.uri".*Cannot fetch .*, error: ',
+            'There was a problem with the request and we have exhausted ',
+            'our retry limit')
       )
 
       result <- dbSendQuery(conn, 'SELECT 3')

--- a/tests/testthat/test-extract.data.R
+++ b/tests/testthat/test-extract.data.R
@@ -69,3 +69,13 @@ with_locale(test.locale(), test_that)('extract.data works', {
     data.frame.with.all.classes()
   )
 })
+
+test_that('extract.data works without column information', {
+  # Sometimes Presto does not return any column information for a chunk,
+  # see https://github.com/prestodb/RPresto/issues/49
+  .extract.data <- RPresto:::.extract.data
+  expect_equal_data_frame(
+    .extract.data(NULL, timezone=test.timezone()),
+    data.frame()
+  )
+})

--- a/tests/testthat/utilities.R
+++ b/tests/testthat/utilities.R
@@ -47,15 +47,34 @@ test.locale <- function() {
 }
 
 with_locale <- function(locale, f) {
-  wrapped <- function(...) {
+  wrapped <- function(desc, ...) {
     old.locale <- Sys.getlocale('LC_CTYPE')
-    Sys.setlocale('LC_CTYPE', locale)
+    tryCatch({
+        Sys.setlocale('LC_CTYPE', locale)
+      },
+      warning=function(w) {
+        warning.message <- conditionMessage(w)
+        if (!grepl(
+          'OS reports request to set locale to .* cannot be honored',
+          warning.message
+        )) {
+          warning(w)
+        }
+      }
+    )
+
     on.exit(Sys.setlocale('LC_CTYPE', old.locale), add=TRUE)
-    f(...)
+    new.locale <- Sys.getlocale('LC_CTYPE')
+    if (new.locale != locale) {
+      return(test_that(desc=desc, {
+        skip(paste0('Cannot set locale to ', locale,
+          'it is set at: ', new.locale))
+      }))
+    }
+    return(f(desc=desc, ...))
   }
   return(wrapped)
 }
-
 
 # Note that you need to wrap your test_that call with with_locale if you
 # use the data returned here for comparison

--- a/tests/testthat/utilities.R
+++ b/tests/testthat/utilities.R
@@ -174,7 +174,9 @@ mock_httr_response <- function(
   } else {
     content <- list()
   }
-  content[['stats']] <- list(state=jsonlite::unbox(state))
+  if (!missing(state)) {
+    content[['stats']] <- list(state=jsonlite::unbox(state))
+  }
   content[['id']] <- jsonlite::unbox(gsub('[:/]', '_', url))
 
   if (!missing(next_uri)) {


### PR DESCRIPTION
- Add retries for 404 codes in GET and POST requests
- Update README with CRAN info
- Return 0-row 0-column data.frame's if we have no information in the response
- Make test cases that require a test locale set to be more robust