### PR TITLE
Handle duplicate columns correctly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # RPresto 1.2.1.9000
 
+- Don't drop data for duplicate column names
+
 # RPresto 1.2.1
 
 - Handle responses with no column information (fixes #49)

--- a/R/dbFetch.R
+++ b/R/dbFetch.R
@@ -79,7 +79,13 @@ NULL
     # Preserve attributes for empty data frames
     return(rv[[1]])
   } else {
-    if (requireNamespace('dplyr', quietly=TRUE)) {
+    # We need to check for the uniqueness of columns because dplyr::bind_rows
+    # will drop duplicate column names and we want to preserve all the data
+    column.names <- names(rv[[1]])
+    if (
+      requireNamespace('dplyr', quietly=TRUE) &&
+      length(column.names) == length(unique(column.names))
+    ) {
       return(as.data.frame(dplyr::bind_rows(rv)))
     } else {
       return(do.call('rbind', rv))

--- a/tests/testthat/test-fetch.R
+++ b/tests/testthat/test-fetch.R
@@ -67,3 +67,13 @@ test_that('fetch works with mock', {
     }
   )
 })
+
+test_that('fetch works with duplicate column names', {
+  conn <- setup_live_connection()
+
+  result <- dbSendQuery(conn, 'SELECT 0 AS dummy, 1 AS dummy')
+  expect_equal_data_frame(
+    dbFetch(result),
+    data.frame(dummy=0, dummy=1, check.names=FALSE)
+  )
+})


### PR DESCRIPTION
The current behavior drops columns that are duplicated. Instead we call
make.names on the columns so we keep all the data. This is the same behavior
that R natively has if you did something like `data.frame(x=1, x=1)`.