### PR TITLE
Add cpp binaries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ tests/testthat/credentials.dcf
 .Rproj.user
 .Rhistory
 .RData
+*./o
+*./so


### PR DESCRIPTION
We will eventually have support for Rcpp, in the meantime this will make
development easier.