### PR TITLE
Fix dbListFields to use the nextUri instead of infoUri

### DIFF
--- a/R/dbFetch.R
+++ b/R/dbFetch.R
@@ -22,7 +22,7 @@ NULL
     error=function (e) {
       if (num.retry == 0) {
         stop("There was a problem with the request ",
-         "and we have exhausted our retry limit")
+         "and we have exhausted our retry limit for uri: ", uri)
       }
       message('GET call failed with error: "', conditionMessage(e),
               '", retrying [', 4 - num.retry, '/3]\n')

--- a/R/dbListFields.R
+++ b/R/dbListFields.R
@@ -26,16 +26,14 @@ setMethod('dbListFields',
     if (!dbIsValid(conn)) {
       stop('The result object is not valid')
     }
-    info.response <- .fetch.uri.with.retries(conn@cursor$infoUri())
-    check.status.code(info.response)
-    info <- response.to.content(info.response)
-    if (!is.null(info[['failureInfo']])
-        && !is.null(info[['failureInfo']][['message']])
-    ) {
-      stop('Query failed: ', info[['failureInfo']][['message']])
+    next.response <- .fetch.uri.with.retries(conn@cursor$nextUri())
+    check.status.code(next.response)
+    content <- response.to.content(next.response)
+    if (get.state(content) == 'FAILED') {
+      stop.with.error.message(content)
     }
-    if (!is.null(info[['fieldNames']])) {
-      rv <- unlist(info[['fieldNames']])
+    if (!is.null(content[['columns']])) {
+      rv <- unlist(lapply(content[['columns']], function(x) x[['name']]))
     } else {
       rv <- character(0)
     }


### PR DESCRIPTION
As of 0.144 Presto returns an HTML page for infoUri. The safest way to
extract the column information thus now seems to be fetching the first
chunk via nextUri and inspecting the data returned.