### PR TITLE
Add support for new types

### DIFF
--- a/R/dbDataType.R
+++ b/R/dbDataType.R
@@ -11,6 +11,10 @@ NULL
 .presto.to.R <- as.data.frame(matrix(c(
   'boolean', 'logical',
   'bigint', 'integer',
+  'integer', 'integer',
+  'smallint', 'integer',
+  'tinyint', 'integer',
+  'decimal', 'numeric',
   'double', 'numeric',
   'varchar', 'character',
   'varbinary', 'raw',


### PR DESCRIPTION
Fixes #56, #60 

Tested locally queries, verified from the release notes these are all the types
that were added.
```
select cast(1 as integer);
select cast(1 as smallint);
select cast(1 as tinyint);
select cast(1 as decimal);
```

@onurfiliz thoughts on changing tests? I feel like this should just work but you
know the unit tests better than me so I would be happy to update things as you
see fit.