### PR TITLE
Add support for row type in Presto queries.

### DIFF
--- a/R/dbDataType.R
+++ b/R/dbDataType.R
@@ -27,7 +27,8 @@ NULL
   'interval year to month', 'character',
   'interval day to second', 'character',
   'array', 'list_unnamed',
-  'map', 'list_named'
+  'map', 'list_named',
+  'row', 'list_named'
 ), byrow=TRUE, ncol=2), stringsAsFactors=FALSE)
 colnames(.presto.to.R) <- c('presto.type', 'R.type')
 

--- a/R/dbFetch.R
+++ b/R/dbFetch.R
@@ -55,6 +55,7 @@ NULL
     )
 
     check.status.code(get.response)
+    # Call response to content, then .extract.data
     content <- response.to.content(get.response)
     if (get.state(content) == 'FAILED') {
       res@cursor$state('FAILED')

--- a/R/extract.data.R
+++ b/R/extract.data.R
@@ -12,6 +12,8 @@ NULL
   data.list <- response.content[['data']]
   if (is.null(data.list)) {
     data.list <- list()
+  } else {
+    print(paste("response.content[['data']] is", data.list))
   }
   column.list <- response.content[['columns']]
   if (is.null(column.list)) {
@@ -22,6 +24,7 @@ NULL
     # name, type, typeSignature
     c('character', 'character', 'list_named')
   )
+  # column.info is a data.frame of name, type, typeSignature now.
   # The typeSignature item for each column has a 'rawType' value which
   # corresponds to the Presto data type.
   presto.types <- vapply(


### PR DESCRIPTION
Summary: Add a mapping to understand the new Row type.

More refactoring work is still required to get the field names, but this at least lets you pull the data without error.
