### PR TITLE
Drop RCurl Dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Depends:
 Imports:
     DBI (>= 0.3.0),
     httr (>= 0.6),
-    RCurl,
+    openssl,
     jsonlite,
     stringi,
     stats,

--- a/R/json.tabular.to.data.frame.R
+++ b/R/json.tabular.to.data.frame.R
@@ -83,7 +83,7 @@ NULL
 
   for (j in which(column.types %in% 'raw')) {
     rv[[j]] <- lapply(rv[[j]], function(txt) {
-      if (is.na(txt)) NA else RCurl::base64Decode(txt, 'raw')
+      if (is.na(txt)) NA else openssl::base64_decode(as.character(txt))
     })
   }
 

--- a/tests/testthat/test-src_translate_env.R
+++ b/tests/testthat/test-src_translate_env.R
@@ -70,7 +70,7 @@ with_locale(test.locale(), test_that)('as() works', {
       s[['con']],
       dplyr::sql('SELECT 1')
     ),
-    vars=list(as.name('x'))
+    vars=c('x')
   )
 
   f <- try(getFromNamespace('src_translate_env', 'dplyr'), silent=TRUE)


### PR DESCRIPTION
Now that `httr` dropped `RCurl` dependency, `RPresto` can drop one more dependency by using `base64decode` from `openssl` instead of `RCurl`.

This is PR is motivated by repeated issues my colleagues and I faced when installing `RCurl`. We often get 404 error like this one: https://github.com/swirldev/swirl/issues/291 
I know this is likely a CRAN mirror issue instead but one less dependency one less thing to worry about 😆 

Also one of the tests failed on me and it looks like due to some `dplyr` changes:
```r
Failed -------------------------------------------------------------------------
1. Error: as() works (@test-src_translate_env.R#67) ----------------------------
is.character(vars) is not TRUE
1: dplyr::tbl(s, from = dplyr::sql_subquery(s[["con"]], dplyr::sql("SELECT 1")), vars = list(as.name("x"))) at /Users/sen_fang/workspace/RPresto/tests/testthat/test-src_translate_env.R:67
2: tbl.src_presto(s, from = dplyr::sql_subquery(s[["con"]], dplyr::sql("SELECT 1")), 
       vars = list(as.name("x")))
3: dplyr::tbl_sql("presto", src = src, from = from, ...) at /Users/sen_fang/workspace/RPresto/R/tbl.src.presto.R:28
4: make_tbl(c(subclass, "sql", "lazy"), src = src, ops = op_base_remote(src, from, vars))
5: structure(list(...), class = c(subclass, "tbl"))
6: op_base_remote(src, from, vars)
7: op_base("remote", src, x, vars)
8: stopifnot(is.character(vars))
9: stop(sprintf(ngettext(length(r), "%s is not TRUE", "%s are not all TRUE"), ch), call. = FALSE, 
       domain = NA)

DONE ===========================================================================
```

All test suites pass otherwise.