### PR TITLE
Support the REAL type

### DIFF
--- a/R/dbDataType.R
+++ b/R/dbDataType.R
@@ -15,6 +15,7 @@ NULL
   'smallint', 'integer',
   'tinyint', 'integer',
   'decimal', 'character',
+  'real', 'numeric',
   'double', 'numeric',
   'varchar', 'character',
   'varbinary', 'raw',


### PR DESCRIPTION
The REAL type is just numeric so we can just add it to the mapping.

Fix for #69. I will add a test to this but I think a previous rev broke tests for live presto sources so I'm going to fix that first.