### PR TITLE
Add source to tests config to make tests pass

### DIFF
--- a/tests/testthat/test-src_translate_env.R
+++ b/tests/testthat/test-src_translate_env.R
@@ -141,7 +141,7 @@ with_locale(test.locale(), test_that)('as() works', {
           '^SELECT "b" AS "b", "c" AS "c", "d" AS "d".*',
           'FROM \\(',
             'SELECT ',
-              '"_col0", ',
+              '"x", ',
               'CAST\\("a" AS "VARBINARY"\\) AS "b", ' ,
               'CAST\\("a" AS "TIMESTAMP WITH TIME ZONE"\\) AS "c", ',
               'CAST\\("a" AS "BOOLEAN"\\) AS "d"\n',

--- a/tests/testthat/utilities.R
+++ b/tests/testthat/utilities.R
@@ -284,7 +284,8 @@ read_credentials <- function() {
     port=as.integer(as.vector(dcf[1, "port"])),
     catalog=as.vector(dcf[1, "catalog"]),
     schema=as.vector(dcf[1, "schema"]),
-    iris_table_name=as.vector(dcf[1, "iris_table_name"])
+    iris_table_name=as.vector(dcf[1, "iris_table_name"]),
+    source=as.vector(dcf[1, "source"])
   )
   return(credentials)
 }


### PR DESCRIPTION
Add a value to pass in as the source, otherwise any tests using a live
connection fails.

We also fix a minor issue with column naming was off, I think this has to do
with dplyr versions

```
> devtools::test()
Loading RPresto
Testing RPresto
bigint handling: ....
check.status.code: ...
data types: ....................
db_explain: ...
db_query_fields: .......
dbClearResult: .....
dbConnect: .....
dbDataType: .......................
dbDisconnect: ..
dbExistsTable: ...
dbFetch: ...................................
dbGetInfo: .............
dbGetQuery: ......
dbGetRowCount: .............
dbGetStatement: ........
dbHasCompleted: ..........
dbIsValid: .........................................
dbListFields: ..............
dbListTables: ....
dbSendQuery: .....................
dbUnloadDriver: .
dplyr: .....
.extract.data: ........
fetch: ..........
get.state: ...
integration: ..............
.json.tabular.to.data.frame: ...............................
PrestoCursor: ...................
response.to.content: .
session.timezone: ........
src_translate_env: .......
stop.with.error.message: .
wait: .

DONE ===========================================================================
```