### PR TITLE
Add source to dplyr example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ db <- src_presto(
   port=7777,
   user=Sys.getenv('USER'),
   schema='<schema>',
-  catalog='<catalog>'
+  catalog='<catalog>',
+  source='<source>'
 )
 
 # Assuming you have a table like iris in the database


### PR DESCRIPTION
The current example will fail because the source needs to be set. Make the
README more explicit.