### PR TITLE
Wrap the `sql` argument to `db_query_fields` with a `sql_subquery`

### DIFF
--- a/R/db_query_fields.R
+++ b/R/db_query_fields.R
@@ -12,7 +12,7 @@
 #' @export
 db_query_fields.PrestoConnection <- function(con, sql, ...) {
   fields <- dplyr::build_sql(
-    "SELECT * FROM ", sql, " LIMIT 0",
+    "SELECT * FROM ", dplyr::sql_subquery(con, sql), " LIMIT 0",
     con = con
   )
   result <- dbSendQuery(con, fields)

--- a/tests/testthat/test-dbFetch.R
+++ b/tests/testthat/test-dbFetch.R
@@ -40,7 +40,8 @@ test_that('dbFetch works with mock', {
         'http://localhost:8000/v1/statement',
         status_code=200,
         state='QUEUED',
-        request_body='SELECT n FROM (VALUES (1), (2)) AS t (n)',
+        request_body=
+          '^SELECT n FROM \\(VALUES \\(1\\), \\(2\\)\\) AS t \\(n\\)$',
         next_uri='http://localhost:8000/query_1/1'
       ),
       mock_httr_response(
@@ -217,7 +218,7 @@ with_locale(test.locale(), test_that)('dbFetch rbind works correctly', {
         'http://localhost:8000/v1/statement',
         status_code=200,
         state='FINISHED',
-        request_body='SELECT * FROM all_types',
+        request_body='SELECT \\* FROM all_types',
         next_uri='http://localhost:8000/query_1/1'
       )
     ),
@@ -280,14 +281,14 @@ with_locale(test.locale(), test_that)('dbFetch rbind works with zero row chunks'
         'http://localhost:8000/v1/statement',
         status_code=200,
         state='PAUSED',
-        request_body='SELECT * FROM all_types',
+        request_body='SELECT \\* FROM all_types',
         next_uri='http://localhost:8000/query_3/1'
       ),
       mock_httr_response(
         'http://localhost:8000/v1/statement',
         status_code=200,
         state='QUEUED',
-        request_body='SELECT * FROM all_types_with_queue',
+        request_body='SELECT \\* FROM all_types_with_queue',
         next_uri='http://localhost:8000/query_4/1'
       )
     ),

--- a/tests/testthat/test-dbListFields.R
+++ b/tests/testthat/test-dbListFields.R
@@ -37,14 +37,14 @@ test_that('dbListFields works with mock - PrestoConnection', {
         'http://localhost:8000/v1/statement',
         status_code=200,
         state='QUEUED',
-        request_body='SELECT * FROM "two_columns" LIMIT 0',
+        request_body='SELECT \\* FROM "two_columns" LIMIT 0',
         next_uri='http://localhost:8000/query_1/1'
       ),
       mock_httr_response(
         'http://localhost:8000/v1/statement',
         status_code=200,
         state='QUEUED',
-        request_body='SELECT * FROM "__non_existent_table__" LIMIT 0',
+        request_body='SELECT \\* FROM "__non_existent_table__" LIMIT 0',
         next_uri='http://localhost:8000/query_2/1'
       )
     ),
@@ -90,21 +90,21 @@ test_that('dbListFields works with mock - PrestoResult', {
         'http://localhost:8000/v1/statement',
         status_code=200,
         state='QUEUED',
-        request_body='SELECT * FROM two_columns',
+        request_body='SELECT \\* FROM two_columns',
         next_uri='http://localhost:8000/query_1/1'
       ),
       mock_httr_response(
         'http://localhost:8000/v1/statement',
         status_code=200,
         state='QUEUED',
-        request_body='SELECT * FROM __non_existent_table__',
+        request_body='SELECT \\* FROM __non_existent_table__',
         next_uri='http://localhost:8000/query_2/1'
       ),
       mock_httr_response(
         'http://localhost:8000/v1/statement',
         status_code=200,
         state='FINISHED',
-        request_body='SELECT * FROM empty_table',
+        request_body='SELECT \\* FROM empty_table',
         next_uri='http://localhost:8000/query_3/1'
       )
     ),

--- a/tests/testthat/test-dbListTables.R
+++ b/tests/testthat/test-dbListTables.R
@@ -28,14 +28,14 @@ test_that('dbListTables works with mock', {
         'http://localhost:8000/v1/statement',
         status_code=200,
         state='QUEUED',
-        request_body='SHOW TABLES',
+        request_body='^SHOW TABLES$',
         next_uri='http://localhost:8000/query_1/1'
       ),
       mock_httr_response(
         'http://localhost:8000/v1/statement',
         status_code=200,
         state='QUEUED',
-        request_body="SHOW TABLES LIKE '_no_table_'",
+        request_body="^SHOW TABLES LIKE '_no_table_'$",
         next_uri='http://localhost:8000/query_2/1'
       )
     ),

--- a/tests/testthat/test-db_query_fields.R
+++ b/tests/testthat/test-db_query_fields.R
@@ -46,7 +46,8 @@ test_that('db_query_fields works with mock', {
         'http://localhost:8000/v1/statement',
         status_code=200,
         state='QUEUED',
-        request_body='SELECT * FROM (SELECT 1 AS a, \'t\' AS b) "a" LIMIT 0',
+        request_body=
+          '^SELECT \\* FROM \\(SELECT 1 AS a, \'t\' AS b\\) "a" LIMIT 0$',
         next_uri='http://localhost:8000/query_1/1',
         info_uri='http://localhost:8000/v1/query/query_1'
       ),
@@ -55,29 +56,71 @@ test_that('db_query_fields works with mock', {
         status_code=200,
         state='QUEUED',
         # For dplyr 0.4.3
-        request_body=
-          'SELECT * FROM (SELECT 1 AS a, \'t\' AS b) AS "a" LIMIT 0',
+        request_body=paste0(
+          '^SELECT \\* FROM ',
+          '\\(\\(SELECT 1 AS a, \'t\' AS b\\) AS "a"\\) ',
+          'AS "zzz[0-9]+" LIMIT 0$'
+        ),
         next_uri='http://localhost:8000/query_1/1'
       ),
       mock_httr_response(
         'http://localhost:8000/v1/statement',
         status_code=200,
         state='QUEUED',
-        request_body='SELECT * FROM "__non_existent_table__" LIMIT 0',
+        # For dplyr 0.5.0
+        request_body=paste0(
+          '^SELECT \\* FROM \\(',
+            '\\(SELECT 1 AS a, \'t\' AS b\\) "a"',
+          '\\) "zzz[0-9]+" LIMIT 0$'
+        ),
+        next_uri='http://localhost:8000/query_1/1'
+      ),
+      mock_httr_response(
+        'http://localhost:8000/v1/statement',
+        status_code=200,
+        state='QUEUED',
+        request_body='^SELECT \\* FROM "__non_existent_table__" LIMIT 0$',
+        next_uri='http://localhost:8000/query_2/1',
+      ),
+      mock_httr_response(
+        'http://localhost:8000/v1/statement',
+        status_code=200,
+        state='QUEUED',
+        # For dplyr 0.5.0
+        request_body=paste0(
+          '^SELECT \\* FROM "__non_existent_table__" ',
+          'AS "zzz[0-9]+" LIMIT 0$'
+        ),
         next_uri='http://localhost:8000/query_2/1',
       ),
       mock_httr_response(
         'http://localhost:8000/v1/statement',
         status_code=200,
         state='FINISHED',
-        request_body='SELECT * FROM "empty_table" LIMIT 0',
+        request_body='^SELECT \\* FROM "empty_table" LIMIT 0$',
+        next_uri='http://localhost:8000/query_3/1',
+      ),
+      mock_httr_response(
+        'http://localhost:8000/v1/statement',
+        status_code=200,
+        state='FINISHED',
+        # For dplyr 0.5.0
+        request_body='^SELECT \\* FROM "empty_table" AS "zzz[0-9]+" LIMIT 0$',
         next_uri='http://localhost:8000/query_3/1',
       ),
       mock_httr_response(
         'http://localhost:8000/v1/statement',
         status_code=200,
         state='QUEUED',
-        request_body='SELECT * FROM "two_columns" LIMIT 0',
+        request_body='^SELECT \\* FROM "two_columns" LIMIT 0$',
+        next_uri='http://localhost:8000/query_4/1',
+      ),
+      mock_httr_response(
+        'http://localhost:8000/v1/statement',
+        status_code=200,
+        state='QUEUED',
+        # For dplyr 0.5.0
+        request_body='^SELECT \\* FROM "two_columns" AS "zzz[0-9]+" LIMIT 0$',
         next_uri='http://localhost:8000/query_4/1',
       )
     ),

--- a/tests/testthat/test-dplyr.integration.R
+++ b/tests/testthat/test-dplyr.integration.R
@@ -27,6 +27,16 @@ test_that('dplyr integration works', {
 
   expect_that(iris_presto, is_a('tbl_presto'))
 
+  # collapse forces the tbl to be a subquery, therefore tests the
+  # db_query_fields path that has `sql` as a subselect as opposed
+  # to a table name. There is some behavioral change between dplyr
+  # 0.4.3 vs 0.5.0 that no longer wraps the former in parentheses
+  # so it should be tested.
+  expect_that(
+    nrow(as.data.frame(dplyr::collapse(iris_presto), n=Inf)),
+    equals(nrow(iris))
+  )
+
   iris_presto_summary <- as.data.frame(dplyr::collect(
     dplyr::rename(
       dplyr::arrange(

--- a/tests/testthat/test-tbl.src_presto.R
+++ b/tests/testthat/test-tbl.src_presto.R
@@ -1,0 +1,30 @@
+# Copyright (c) 2015-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+context('tbl.src_presto')
+
+source('utilities.R')
+
+test_that('dplyr::tbl works', {
+  parts <- setup_live_dplyr_connection()
+
+  iris_presto <- dplyr::tbl(parts[['db']], parts[['iris_table_name']])
+  iris_presto_materialized <- as.data.frame(iris_presto, n=Inf)
+  expect_that(
+    nrow(iris_presto_materialized),
+    equals(nrow(iris))
+  )
+
+  iris_from_sql <- dplyr::tbl(
+    parts[['db']],
+    dplyr::sql(paste('SELECT * FROM', parts[['iris_table_name']]))
+  )
+  expect_equal(
+    iris_presto_materialized,
+    as.data.frame(dplyr::collect(iris_from_sql, n=Inf))
+  )
+})

--- a/tests/testthat/utilities.R
+++ b/tests/testthat/utilities.R
@@ -253,7 +253,7 @@ mock_httr_replies <- function(...) {
       } else {
         body.matches <- (
           !is.null(item[['request_body']])
-          && item[['request_body']] == body
+          && grepl(item[['request_body']], body)
         )
       }
 


### PR DESCRIPTION
There is some behavioral change between dplyr 0.4.3 and 0.5.0
in the `sql` argument to `db_query_fields`. If it is a subquery (as
opposed to a table name), it is no longer wrapped in parentheses. We
then end up with an invalid SQL string that looks like:

    SELECT * FROM SELECT ...

Wrapping it with `sql_subquery` fixes the issue for 0.5.0. It still
works for 0.4.3, since it just adds another pair of parentheses.