### PR TITLE
Get ready to submit a new version to CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RPresto
 Title: DBI Connector to Presto
-Version: 1.2.1.9000
+Version: 1.3.0
 Authors@R: c(
     person('Onur Ismail', 'Filiz', , 'onur@fb.com', role=c('aut', 'cre')),
     person('Sergey', 'Goder', , 'sgoder@fb.com', role='aut'),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,10 +21,12 @@ Imports:
     jsonlite,
     stringi,
     stats,
-    Rcpp
+    Rcpp,
+    utils
 Suggests:
     testthat,
-    dplyr (>= 0.4.3)
+    dplyr (>= 0.4.3),
+    dbplyr
 License: BSD_3_clause + file LICENSE
 URL: https://github.com/prestodb/RPresto
 BugReports: https://github.com/prestodb/RPresto/issues
@@ -62,6 +64,7 @@ Collate:
     'dbIsValid.R'
     'dbListFields.R'
     'dbUnloadDriver.R'
+    'description_from_info.R'
     'db_desc.PrestoConnection.R'
     'db_query_fields.R'
     'fetch.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ URL: https://github.com/prestodb/RPresto
 BugReports: https://github.com/prestodb/RPresto/issues
 Encoding: UTF-8
 LazyData: true
-Collate: 
+Collate:
     'PrestoDriver.R'
     'Presto.R'
     'utility_functions.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,22 @@
-# RPresto 1.2.1.9000
+# RPresto 1.3.0
 
-- Don't drop data for duplicate column names
+- Fix Rcpp compilation under Windows (#79)
 - `SET/RESET SESSION` queries are now correctly respected when used under `dbGetQuery`.
   `PrestoConnection` no longer has `parameters` slot but `dbConnect` remains backward
-  compatible. Manual change to parameter is still possible via `conn@session$setParameter()`.
-
+  compatible. Manual change to parameter is still possible via `conn@session$setParameter()` (#77)
+- Adapt to changes in dplyr version 0.7.0, mainly around the remote
+  backend support being split to `dbplyr`. This should be backwards compatible
+  back to dplyr 0.4.3 (#76)
+- Add support for the REAL data type (#70)
+- Allow specifying the connection source (#68)
+- Drop RCurl dependency (#67)
+- Return DECIMAL data types as characters as opposed to numeric's
+  previously (#64, fixes #60)
+- Add support for new integer data types (INTEGER, SMALLINT, TINYINT) (#59, fixes #56)
+- Migrate the  `json` to `data.frame` construction from pure R to Rcpp for 10x
+  speed gains! (thanks @saurfang) (#57, #58)
+- Fix dbListFields to use the nextUri instead of infoUri (#55)
+- Don't drop data for duplicate column names (#53)
 
 # RPresto 1.2.1
 

--- a/R/db_desc.PrestoConnection.R
+++ b/R/db_desc.PrestoConnection.R
@@ -5,7 +5,10 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-#' S3 implementation of \code{\link[dplyr]{db_desc}} for Presto.
+#' @include description_from_info.R
+NULL
+
+#' S3 implementation of \code{db_desc} for Presto.
 #'
 #' @rdname dplyr_function_implementations
 #' @keywords internal
@@ -15,19 +18,3 @@ db_desc.PrestoConnection <- function(x) {
   return(.description_from_info(info))
 }
 
-.description_from_info <- function(info) {
-  return(paste0(
-    'presto ',
-    ' [',
-    info[['schema']],
-    ':',
-    info[['catalog']],
-    ' | ',
-    info[['user']],
-    '@',
-    info[['host']],
-    ':',
-    info[['port']],
-    ']'
-  ))
-}

--- a/R/dbplyr_compatible.R
+++ b/R/dbplyr_compatible.R
@@ -9,15 +9,15 @@
 # dplyr 0.6.0 release. This function allows us to provide backward
 # compatibility by importing from dplyr when necessary.
 dbplyr_compatible <- function(function_name) {
-  if (packageVersion('dplyr') >= '0.5.0.9004') {
+  if (utils::packageVersion('dplyr') >= '0.5.0.9004') {
     if (!requireNamespace('dbplyr', quietly=TRUE)) {
       stop(function_name, ' requires the dbplyr package, please install it ',
         'first and try again'
       )
     }
-    f <- getFromNamespace(function_name, 'dbplyr')
+    f <- utils::getFromNamespace(function_name, 'dbplyr')
   } else {
-    f <- getFromNamespace(function_name, 'dplyr')
+    f <- utils::getFromNamespace(function_name, 'dplyr')
   }
   return(f)
 }

--- a/R/description_from_info.R
+++ b/R/description_from_info.R
@@ -5,16 +5,19 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-#' @include description_from_info.R
-NULL
-
-
-#' S3 implementation of \code{src_desc} for Presto.
-#'
-#' @rdname dplyr_function_implementations
-#' @keywords internal
-#' @export
-src_desc.src_presto <- function(x) {
-  info <- x[['info']]
-  return(.description_from_info(info))
+.description_from_info <- function(info) {
+  return(paste0(
+    'presto ',
+    ' [',
+    info[['schema']],
+    ':',
+    info[['catalog']],
+    ' | ',
+    info[['user']],
+    '@',
+    info[['host']],
+    ':',
+    info[['port']],
+    ']'
+  ))
 }

--- a/R/src.presto.R
+++ b/R/src.presto.R
@@ -56,17 +56,17 @@ src_presto <- function(
     ...
   )
 
-  if (packageVersion('dplyr') >= '0.5.0.9004') {
+  if (utils::packageVersion('dplyr') >= '0.5.0.9004') {
     if (!requireNamespace('dbplyr', quietly=TRUE)) {
       stop('src_presto requires the dbplyr package, please install it first ',
            'and try again'
       )
     }
-    src_function <- getFromNamespace('src_dbi', 'dbplyr')
+    src_function <- utils::getFromNamespace('src_dbi', 'dbplyr')
     src <- src_function(con, auto_disconnect=FALSE)
   } else {
     info <- DBI::dbGetInfo(con)
-    src_function <- getFromNamespace('src_sql', 'dplyr')
+    src_function <- utils::getFromNamespace('src_sql', 'dplyr')
     src <- src_function(
       "presto",
       con,

--- a/R/src.translate.env.src.presto.R
+++ b/R/src.translate.env.src.presto.R
@@ -8,6 +8,23 @@
 #' @include dbplyr_compatible.R
 NULL
 
+presto_window_functions <- function() {
+  base_win <- dbplyr_compatible('base_win')
+  if (utils::packageVersion('dplyr') < '0.5.0.9004') {
+    return(base_win)
+  }
+  sql_translator <- dbplyr_compatible('sql_translator')
+  win_absent <- dbplyr_compatible('win_absent')
+  win_recycled <- dbplyr_compatible('win_recycled')
+  return(sql_translator(
+    .parent=base_win,
+    all=win_recycled('bool_and'),
+    or=win_recycled('bool_or'),
+    n_distinct=win_absent('n_distinct'),
+    sd=win_recycled("stddev_samp")
+  ))
+}
+
 #' S3 implementation of \code{src_translate_env} for Presto.
 #'
 #' @rdname dplyr_function_implementations
@@ -21,7 +38,6 @@ src_translate_env.src_presto <- function(x) {
   build_sql <- dbplyr_compatible('build_sql')
   base_scalar <- dbplyr_compatible('base_scalar')
   base_agg <- dbplyr_compatible('base_agg')
-  base_win <- dbplyr_compatible('base_win')
   ident <- dbplyr_compatible('ident')
   return(sql_variant(
     sql_translator(.parent = base_scalar,
@@ -48,6 +64,6 @@ src_translate_env.src_presto <- function(x) {
       all = sql_prefix("bool_and"),
       any = sql_prefix("bool_or")
     ),
-    base_win
+    presto_window_functions()
   ))
 }

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,13 +1,13 @@
 # Test environments
 
-- OS X 10.10.5 Yosemite, R 3.1.0
-- CentOS 6.7, R 3.2.4
+- OS X 10.12.1 Sierra, R 3.4.1
+- CentOS 7.3, R 3.3.2
 - win-builder (devel and release)
-- WinXP, R 3.2.4
 
 # R CMD check results
 
-0 errors | 0 warnings | 1 note
+For OS X and CentOS: 0 errors | 0 warnings | 0 notes
 
-- The 'note' is about the LICENSE file which is the BSD 3-clause license.
-- win-builder also points out that the 'DBI' and 'SQL' words in the Description might have been mis-spelled but the usage is intentional.
+For win-builder: 0 errors | 0 warnings | 1 note
+
+- win-builder note points out that the 'DBI' and 'SQL' words in the Description might have been mis-spelled but the usage is intentional.

--- a/man/dplyr_function_implementations.Rd
+++ b/man/dplyr_function_implementations.Rd
@@ -43,7 +43,7 @@ S3 implementation of \code{\link[dplyr]{db_explain}} for Presto.
 
 S3 implementation of \code{\link[dplyr]{db_query_rows}} for Presto.
 
-S3 implementation of \code{\link[dplyr]{db_desc}} for Presto.
+S3 implementation of \code{db_desc} for Presto.
 
 S3 implementation of \code{sql_translate_env} for Presto.
 
@@ -51,6 +51,6 @@ S3 implementation of \code{src_translate_env} for Presto.
 
 S3 implementation of \code{sql_translate_env} for Presto.
 
-S3 implementation of \code{\link[dplyr]{src_desc}} for Presto.
+S3 implementation of \code{src_desc} for Presto.
 }
 \keyword{internal}

--- a/tests/testthat/test-dbDataType.R
+++ b/tests/testthat/test-dbDataType.R
@@ -29,7 +29,7 @@ with_locale(test.locale(), test_that)('presto simple types are correct', {
     expect_equal(dbDataType(drv, factor()), 'VARCHAR')
     expect_equal(dbDataType(drv, factor(ordered=TRUE)), 'VARCHAR')
     expect_equal(
-      dbDataType(drv, structure(NULL, class='test_class')),
+      dbDataType(drv, structure(list(), class='test_class')),
       'VARCHAR'
     )
 })

--- a/tests/testthat/test-src_translate_env.R
+++ b/tests/testthat/test-src_translate_env.R
@@ -136,7 +136,8 @@ with_locale(test.locale(), test_that)('as() works', {
       r <- as.raw(0)
       p <- as.POSIXct('2001-02-03 04:05:06', tz='Europe/Istanbul')
       l <- TRUE
-      query <- as.character(dbplyr::sql_render(dplyr::transmute(
+      sql_render <- RPresto:::dbplyr_compatible('sql_render')
+      query <- as.character(sql_render(dplyr::transmute(
         t,
         b=as(a, r),
         c=as(a, p),

--- a/tests/testthat/test-src_translate_env.R
+++ b/tests/testthat/test-src_translate_env.R
@@ -10,6 +10,9 @@ context('src_translate_env')
 source('utilities.R')
 
 with_locale(test.locale(), test_that)('as() works', {
+  if (!requireNamespace('dplyr', quietly=TRUE)) {
+    skip('dplyr not available')
+  }
 
   translate_sql <- RPresto:::dbplyr_compatible('translate_sql')
   translate_sql_ <- RPresto:::dbplyr_compatible('translate_sql_')


### PR DESCRIPTION
With the latest dplyr release (0.7.0) the CRAN version started giving build failures so we should push a new version. I bumped the minor version due to the huge speedups by @saurfang through Rcpp.