### PR TITLE
Fix translation of `all` in window functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
     jsonlite,
     stringi,
     stats,
-    Rcpp,
+    Rcpp (>= 0.12.7),
     utils
 Suggests:
     testthat,

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2,10 +2,10 @@
 # Generator token: 10BE3573-1514-4C36-9D1C-5A225CD40393
 
 check_names <- function(x, column_count) {
-    .Call('RPresto_check_names', PACKAGE = 'RPresto', x, column_count)
+    .Call('_RPresto_check_names', PACKAGE = 'RPresto', x, column_count)
 }
 
 transpose <- function(input, output) {
-    .Call('RPresto_transpose', PACKAGE = 'RPresto', input, output)
+    .Call('_RPresto_transpose', PACKAGE = 'RPresto', input, output)
 }
 

--- a/R/src.translate.env.src.presto.R
+++ b/R/src.translate.env.src.presto.R
@@ -19,7 +19,7 @@ presto_window_functions <- function() {
   return(sql_translator(
     .parent=base_win,
     all=win_recycled('bool_and'),
-    or=win_recycled('bool_or'),
+    any=win_recycled('bool_or'),
     n_distinct=win_absent('n_distinct'),
     sd=win_recycled("stddev_samp")
   ))

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -7,7 +7,7 @@ using namespace Rcpp;
 
 // check_names
 SEXP check_names(List x, int column_count);
-RcppExport SEXP RPresto_check_names(SEXP xSEXP, SEXP column_countSEXP) {
+RcppExport SEXP _RPresto_check_names(SEXP xSEXP, SEXP column_countSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -19,7 +19,7 @@ END_RCPP
 }
 // transpose
 List transpose(List input, List output);
-RcppExport SEXP RPresto_transpose(SEXP inputSEXP, SEXP outputSEXP) {
+RcppExport SEXP _RPresto_transpose(SEXP inputSEXP, SEXP outputSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -31,8 +31,8 @@ END_RCPP
 }
 
 static const R_CallMethodDef CallEntries[] = {
-    {"RPresto_check_names", (DL_FUNC) &RPresto_check_names, 2},
-    {"RPresto_transpose", (DL_FUNC) &RPresto_transpose, 2},
+    {"_RPresto_check_names", (DL_FUNC) &_RPresto_check_names, 2},
+    {"_RPresto_transpose", (DL_FUNC) &_RPresto_transpose, 2},
     {NULL, NULL, 0}
 };
 


### PR DESCRIPTION
Seems like this was just a typo. Make sure tests don't show warnings anymore
```
R> devtools::test(filter='src_translate_env')
Loading RPresto
Loading required package: testthat
Testing RPresto
src_translate_env: ....S

Skipped ------------------------------------------------------------------------
1. as() works (@test-src_translate_env.R#76) - credential file missing, please create a file  with fields "host", "por
t", "source", "catalog", "schema" to do live testing

DONE ===========================================================================
R>
```
I guess Rcpp changed how it generates files so those got included as well