### PR TITLE
Handle unknown column types explicitly

### DIFF
--- a/R/dbDataType.R
+++ b/R/dbDataType.R
@@ -28,7 +28,8 @@ NULL
   'interval year to month', 'character',
   'interval day to second', 'character',
   'array', 'list_unnamed',
-  'map', 'list_named'
+  'map', 'list_named',
+  'unknown', 'unknown'
 ), byrow=TRUE, ncol=2), stringsAsFactors=FALSE)
 colnames(.presto.to.R) <- c('presto.type', 'R.type')
 

--- a/R/json.tabular.to.data.frame.R
+++ b/R/json.tabular.to.data.frame.R
@@ -68,6 +68,9 @@ NULL
       POSIXct_with_time_zone=rep(NA_character_, row.count),
       list_unnamed=as.list(rep(NA, row.count)),
       list_named=as.list(rep(NA, row.count)),
+      unknown=stop(
+        'Unknown column type, make sure all columns in the query have a type'
+      ),
       stop('Unsupported column type: ', type)
     )
     if (type %in% 'POSIXct_with_time_zone') {

--- a/tests/testthat/test-data_types.R
+++ b/tests/testthat/test-data_types.R
@@ -18,7 +18,7 @@ test_that("Queries return the correct primitive types", {
   conn <- setup_live_connection()
 
   expect_error(dbGetQuery(conn, "select null unknown"),
-               'Unsupported column type',
+               'Unknown column type',
                label='column of type "unknown"')
   expect_equal_data_frame(dbGetQuery(conn, "select true bool"),
                data_frame(bool = TRUE))


### PR DESCRIPTION
See https://github.com/prestodb/RPresto/issues/84 we can just be more explicit for users about this case