### PR TITLE
Add presto column type and column index to error message

### DIFF
--- a/R/extract.data.R
+++ b/R/extract.data.R
@@ -20,7 +20,7 @@ NULL
   column.info <- .json.tabular.to.data.frame(
     column.list,
     # name, type, typeSignature
-    c('character', 'character', 'list_named')
+    c(varchar='character', varchar='character', map='list_named')
   )
   # The typeSignature item for each column has a 'rawType' value which
   # corresponds to the Presto data type.
@@ -30,6 +30,7 @@ NULL
     ''
   )
   r.types <- with(.presto.to.R, R.type[match(presto.types, presto.type)])
+  names(r.types) <- presto.types
   rv <- .json.tabular.to.data.frame(data.list, r.types, timezone=timezone)
   if (!is.null(column.info[['name']])) {
     colnames(rv) <- column.info[['name']]

--- a/R/json.tabular.to.data.frame.R
+++ b/R/json.tabular.to.data.frame.R
@@ -69,9 +69,18 @@ NULL
       list_unnamed=as.list(rep(NA, row.count)),
       list_named=as.list(rep(NA, row.count)),
       unknown=stop(
-        'Unknown column type, make sure all columns in the query have a type'
+        sprintf(paste0(
+          '"unknown" column type for column [%d], ',
+          'CAST() it to a known column type'
+        ), j)
       ),
-      stop('Unsupported column type: ', type)
+      stop(
+        sprintf(paste0(
+          'Unsupported column type for column [%d], ',
+          'presto type: "%s", ',
+          'R type: "%s"'
+        ), j, names(column.types)[j], type)
+      )
     )
     if (type %in% 'POSIXct_with_time_zone') {
       attr(rv[[j]], 'tzone') <- 'UTC'

--- a/tests/testthat/test-data_types.R
+++ b/tests/testthat/test-data_types.R
@@ -18,7 +18,7 @@ test_that("Queries return the correct primitive types", {
   conn <- setup_live_connection()
 
   expect_error(dbGetQuery(conn, "select null unknown"),
-               'Unknown column type',
+               '"unknown" column type',
                label='column of type "unknown"')
   expect_equal_data_frame(dbGetQuery(conn, "select true bool"),
                data_frame(bool = TRUE))


### PR DESCRIPTION
The error message when we cannot map the presto data type
to an R type is pretty opaque. Improve it by making the column.types
argument to .json.tabular.to.data.frame have the presto data
types as names.