### PR TITLE
Adapt to change in presto syntax for CAST()

### DIFF
--- a/R/src.translate.env.src.presto.R
+++ b/R/src.translate.env.src.presto.R
@@ -38,7 +38,6 @@ src_translate_env.src_presto <- function(x) {
   build_sql <- dbplyr_compatible('build_sql')
   base_scalar <- dbplyr_compatible('base_scalar')
   base_agg <- dbplyr_compatible('base_agg')
-  ident <- dbplyr_compatible('ident')
   return(sql_variant(
     sql_translator(.parent = base_scalar,
       ifelse = sql_prefix("if"),

--- a/R/src.translate.env.src.presto.R
+++ b/R/src.translate.env.src.presto.R
@@ -47,7 +47,7 @@ src_translate_env.src_presto <- function(x) {
           dbDataType(Presto(), type),
           'en_US.UTF-8'
         )
-        build_sql('CAST(', column, ' AS ', ident(sql_type), ')')
+        build_sql('CAST(', column, ' AS ', sql(sql_type), ')')
       },
       tolower = sql_prefix("lower"),
       toupper = sql_prefix("upper"),

--- a/tests/testthat/test-src_translate_env.R
+++ b/tests/testthat/test-src_translate_env.R
@@ -27,31 +27,31 @@ with_locale(test.locale(), test_that)('as() works', {
     v <- src_translate_env(conn)
     expect_equal(
       translate_sql(as(x, 0.0), variant=v),
-      dplyr::sql('CAST("x" AS "DOUBLE")')
+      dplyr::sql('CAST("x" AS DOUBLE)')
     )
     expect_equal(
       dplyr::translate_sql_q(
         list(substitute(as(x, l), list(l=list()))),
         variant=v
       ),
-      dplyr::sql('CAST("x" AS "ARRAY<VARCHAR>")')
+      dplyr::sql('CAST("x" AS ARRAY<VARCHAR>)')
     )
 
     substituted.expression <- substitute(as(x, l), list(l=Sys.Date()))
     expect_equal(
       dplyr::translate_sql_q(list(substituted.expression), variant=v),
-      dplyr::sql('CAST("x" AS "DATE")')
+      dplyr::sql('CAST("x" AS DATE)')
     )
 
     substituted.expression <- substitute(as(x, l), list(l=Sys.Date()))
     expect_equal(
       dplyr::translate_sql_q(list(substituted.expression), variant=v),
-      dplyr::sql('CAST("x" AS "DATE")')
+      dplyr::sql('CAST("x" AS DATE)')
     )
   } else {
     expect_equal(
       translate_sql(as(x, 0.0), con=conn[['con']]),
-      dplyr::sql('CAST("x" AS "DOUBLE")')
+      dplyr::sql('CAST("x" AS DOUBLE)')
     )
     expect_equal(
       translate_sql(pmax(x), con=conn[['con']]),
@@ -62,13 +62,13 @@ with_locale(test.locale(), test_that)('as() works', {
         list(substitute(as(x, l), list(l=list()))),
         con=conn[['con']]
       ),
-      dplyr::sql('CAST("x" AS "ARRAY<VARCHAR>")')
+      dplyr::sql('CAST("x" AS ARRAY<VARCHAR>)')
     )
 
     substituted.expression <- substitute(as(x, l), list(l=Sys.Date()))
     expect_equal(
       translate_sql_(list(substituted.expression), con=conn[['con']]),
-      dplyr::sql('CAST("x" AS "DATE")')
+      dplyr::sql('CAST("x" AS DATE)')
     )
   }
 
@@ -87,12 +87,12 @@ with_locale(test.locale(), test_that)('as() works', {
     l <- list(a=1L)
     expect_equal(
       translate_sql(as(x, l), tbl=t),
-      dplyr::sql('CAST("x" AS "MAP<VARCHAR, BIGINT>")')
+      dplyr::sql('CAST("x" AS MAP<VARCHAR, BIGINT>)')
     )
 
     expect_equal(
       translate_sql(as(x, local(list(a=Sys.time()))), tbl=t),
-      dplyr::sql('CAST("x" AS "MAP<VARCHAR, TIMESTAMP>")')
+      dplyr::sql('CAST("x" AS MAP<VARCHAR, TIMESTAMP>)')
     )
 
     r <- as.raw(0)
@@ -111,9 +111,9 @@ with_locale(test.locale(), test_that)('as() works', {
       grepl(
         paste0(
           '^SELECT ',
-          'CAST\\("a" AS "VARBINARY"\\) AS "b", ' ,
-          'CAST\\("a" AS "TIMESTAMP WITH TIME ZONE"\\) AS "c", ',
-          'CAST\\("a" AS "BOOLEAN"\\) AS "d"\n',
+          'CAST\\("a" AS VARBINARY\\) AS "b", ' ,
+          'CAST\\("a" AS TIMESTAMP WITH TIME ZONE\\) AS "c", ',
+          'CAST\\("a" AS BOOLEAN\\) AS "d"\n',
           'FROM \\(\\(SELECT 1\\) AS "(_W|zzz)\\d+"\\) AS "[_0-9a-z]+"$'
         ),
         query
@@ -127,14 +127,14 @@ with_locale(test.locale(), test_that)('as() works', {
           as(x, !!l),
           con=s[['con']]
         ),
-        dplyr::sql('CAST("x" AS "MAP<VARCHAR, BIGINT>")')
+        dplyr::sql('CAST("x" AS MAP<VARCHAR, BIGINT>)')
       )
       expect_equal(
         translate_sql(
           as(x, !!local(list(a=Sys.time()))),
           con=s[['con']]
         ),
-        dplyr::sql('CAST("x" AS "MAP<VARCHAR, TIMESTAMP>")')
+        dplyr::sql('CAST("x" AS MAP<VARCHAR, TIMESTAMP>)')
       )
       r <- as.raw(0)
       p <- as.POSIXct('2001-02-03 04:05:06', tz='Europe/Istanbul')
@@ -153,9 +153,9 @@ with_locale(test.locale(), test_that)('as() works', {
             'FROM \\(',
               'SELECT ',
                 '"_col0", ',
-                'CAST\\("a" AS "VARBINARY"\\) AS "b", ' ,
-                'CAST\\("a" AS "TIMESTAMP WITH TIME ZONE"\\) AS "c", ',
-                'CAST\\("a" AS "BOOLEAN"\\) AS "d"\n',
+                'CAST\\("a" AS VARBINARY\\) AS "b", ' ,
+                'CAST\\("a" AS TIMESTAMP WITH TIME ZONE\\) AS "c", ',
+                'CAST\\("a" AS BOOLEAN\\) AS "d"\n',
               'FROM \\(',
                 '\\(SELECT 1\\) "[_0-9a-z]+"',
               '\\) "[_0-9a-z]+"',
@@ -168,7 +168,7 @@ with_locale(test.locale(), test_that)('as() works', {
       l <- list(a=1L)
       expect_equal(
         translate_sql(as(x, l), con=s[['con']], vars='x'),
-        dplyr::sql('CAST("x" AS "MAP<VARCHAR, BIGINT>")')
+        dplyr::sql('CAST("x" AS MAP<VARCHAR, BIGINT>)')
       )
 
       expect_equal(
@@ -177,7 +177,7 @@ with_locale(test.locale(), test_that)('as() works', {
           vars='x',
           con=s[['con']]
         ),
-        dplyr::sql('CAST("x" AS "MAP<VARCHAR, TIMESTAMP>")')
+        dplyr::sql('CAST("x" AS MAP<VARCHAR, TIMESTAMP>)')
       )
 
       r <- as.raw(0)
@@ -196,9 +196,9 @@ with_locale(test.locale(), test_that)('as() works', {
             'FROM \\(',
               'SELECT ',
                 '"x", ',
-                'CAST\\("a" AS "VARBINARY"\\) AS "b", ' ,
-                'CAST\\("a" AS "TIMESTAMP WITH TIME ZONE"\\) AS "c", ',
-                'CAST\\("a" AS "BOOLEAN"\\) AS "d"\n',
+                'CAST\\("a" AS VARBINARY\\) AS "b", ' ,
+                'CAST\\("a" AS TIMESTAMP WITH TIME ZONE\\) AS "c", ',
+                'CAST\\("a" AS BOOLEAN\\) AS "d"\n',
               'FROM \\(',
                 '\\(SELECT 1\\) "[_0-9a-z]+"',
               '\\) "[_0-9a-z]+"',


### PR DESCRIPTION
Presto does not allow double quotes for type names in CAST() anymore.