### PR TITLE
Handle data in POST response

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ URL: https://github.com/prestodb/RPresto
 BugReports: https://github.com/prestodb/RPresto/issues
 Encoding: UTF-8
 LazyData: true
-Collate:
+Collate: 
     'PrestoDriver.R'
     'Presto.R'
     'utility_functions.R'
@@ -54,6 +54,7 @@ Collate:
     'dbSendQuery.R'
     'json.tabular.to.data.frame.R'
     'extract.data.R'
+    'parse.response.R'
     'dbFetch.R'
     'dbGetQuery.R'
     'dbListTables.R'

--- a/R/PrestoResult.R
+++ b/R/PrestoResult.R
@@ -21,7 +21,6 @@ NULL
 setClass('PrestoResult',
   contains='DBIResult',
   slots=c(
-    'post.response'='ANY',
     'statement'='character',
     'session.timezone'='character',
     'cursor'='PrestoCursor',
@@ -34,7 +33,7 @@ setClass('PrestoResult',
 setMethod('show',
   'PrestoResult',
   function(object) {
-    r <- object@post.response
+    r <- object@cursor$postResponse()
     content <- response.to.content(r)
     stats <- object@cursor$stats()
 

--- a/R/dbFetch.R
+++ b/R/dbFetch.R
@@ -6,7 +6,7 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 
 #' @include extract.data.R json.tabular.to.data.frame.R
-#' @include utility_functions.R PrestoResult.R
+#' @include utility_functions.R PrestoResult.R parse.response.R
 NULL
 
 .fetch.uri.with.retries <- function(uri, num.retry=3) {
@@ -53,40 +53,7 @@ NULL
         ))
       }
     )
-
-    check.status.code(get.response)
-    content <- response.to.content(get.response)
-    if (get.state(content) == 'FAILED') {
-      res@cursor$state('FAILED')
-      res@cursor$stats(content[['stats']])
-      stop.with.error.message(content)
-    }
-
-    # Handle SET/RESET SESSION updates
-    if (!is.null(content[['updateType']])) {
-      switch(
-        content[['updateType']],
-        'SET SESSION' = {
-          properties <- httr::headers(get.response)[['x-presto-set-session']]
-          if (!is.null(properties)) {
-            for (pair in strsplit(properties, ',', fixed = TRUE)) {
-              pair <- unlist(strsplit(pair, '=', fixed = TRUE))
-              res@session$setParameter(pair[1], pair[2])
-            }
-          }
-        },
-        'RESET SESSION' = {
-          properties <- httr::headers(get.response)[['x-presto-clear-session']]
-          if (!is.null(properties)) {
-            for (key in strsplit(properties, ',', fixed = TRUE)) {
-              res@session$unsetParameter(key)
-            }
-          }
-        })
-    }
-
-    df <- .extract.data(content, timezone=res@session.timezone)
-    res@cursor$updateCursor(content, NROW(df))
+    df <- .parse.response(res, get.response)
   }
   return(df)
 }

--- a/R/dbFetch.R
+++ b/R/dbFetch.R
@@ -96,6 +96,15 @@ NULL
   return(.fetch.all(res))
 }
 
+.fetch.next.chunk <- function(res, n, ...) {
+  if (!res@cursor$postDataParsed()) {
+    df <- .parse.response(res, res@cursor$postResponse())
+    res@cursor$postDataParsed(TRUE)
+    return(df)
+  }
+  return(.fetch.single.uri(res, n, ...))
+}
+
 #' @rdname PrestoResult-class
 #' @export
 setMethod('dbFetch', c('PrestoResult', 'integer'), .fetch.with.count)
@@ -106,4 +115,4 @@ setMethod('dbFetch', c('PrestoResult', 'numeric'), .fetch.with.count)
 
 #' @rdname PrestoResult-class
 #' @export
-setMethod('dbFetch', c('PrestoResult', 'missing'), .fetch.single.uri)
+setMethod('dbFetch', c('PrestoResult', 'missing'), .fetch.next.chunk)

--- a/R/dbListFields.R
+++ b/R/dbListFields.R
@@ -26,7 +26,11 @@ setMethod('dbListFields',
     if (!dbIsValid(conn)) {
       stop('The result object is not valid')
     }
-    next.response <- .fetch.uri.with.retries(conn@cursor$nextUri())
+    if (!conn@cursor$postDataParsed()) {
+      next.response <- conn@cursor$postResponse()
+    } else {
+      next.response <- .fetch.uri.with.retries(conn@cursor$nextUri())
+    }
     check.status.code(next.response)
     content <- response.to.content(next.response)
     if (get.state(content) == 'FAILED') {

--- a/R/dbSendQuery.R
+++ b/R/dbSendQuery.R
@@ -39,9 +39,8 @@ NULL
     if (get.state(content) == 'FAILED') {
       stop.with.error.message(content)
     } else {
-      cursor <- PrestoCursor$new(content)
+      cursor <- PrestoCursor$new(post.response)
       rv <- new('PrestoResult',
-        post.response=post.response,
         statement=statement,
         session.timezone=conn@session.timezone,
         cursor=cursor,

--- a/R/parse.response.R
+++ b/R/parse.response.R
@@ -1,0 +1,51 @@
+# Copyright (c) 2015-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+#' @include utility_functions.R extract.data.R
+NULL
+
+.parse.response <- function(result, response) {
+  if (!dbIsValid(result)) {
+    stop('Result object is not valid')
+  }
+  df <- data.frame()
+  check.status.code(response)
+  content <- response.to.content(response)
+
+  if (get.state(content) == 'FAILED') {
+    result@cursor$state('FAILED')
+    result@cursor$stats(content[['stats']])
+    stop.with.error.message(content)
+  }
+
+  # Handle SET/RESET SESSION updates
+  if (!is.null(content[['updateType']])) {
+    switch(
+      content[['updateType']],
+      'SET SESSION' = {
+        properties <- httr::headers(response)[['x-presto-set-session']]
+        if (!is.null(properties)) {
+          for (pair in strsplit(properties, ',', fixed = TRUE)) {
+            pair <- unlist(strsplit(pair, '=', fixed = TRUE))
+            result@session$setParameter(pair[1], pair[2])
+          }
+        }
+      },
+      'RESET SESSION' = {
+        properties <- httr::headers(response)[['x-presto-clear-session']]
+        if (!is.null(properties)) {
+          for (key in strsplit(properties, ',', fixed = TRUE)) {
+            result@session$unsetParameter(key)
+          }
+        }
+      }
+    )
+  }
+  df <- .extract.data(content, timezone=result@session.timezone)
+  result@cursor$updateCursor(content, NROW(df))
+  return(df)
+}

--- a/tests/testthat/test-PrestoCursor.R
+++ b/tests/testthat/test-PrestoCursor.R
@@ -10,9 +10,22 @@ context('PrestoCursor')
 source('utilities.R')
 
 test_that('PrestoCursor methods work correctly', {
-    post.content <- list(stats=list(state='INITIAL'))
+    post.content <- list(stats=list(
+      state=jsonlite::unbox('INITIAL')
+    ))
+    post.response <- structure(
+      list(
+        url='http://localhost:8000/v1/statement',
+        status_code=200,
+        headers=list(
+          'content-type'='application/json'
+        ),
+        content=charToRaw(jsonlite::toJSON(post.content))
+      ),
+      class='response'
+    )
 
-    cursor <- PrestoCursor(post.content)
+    cursor <- PrestoCursor(post.response)
     expect_equal(cursor$infoUri(), '')
     expect_equal(cursor$nextUri(), '')
     expect_equal(cursor$state(), 'INITIAL')

--- a/tests/testthat/test-PrestoCursor.R
+++ b/tests/testthat/test-PrestoCursor.R
@@ -32,6 +32,10 @@ test_that('PrestoCursor methods work correctly', {
     expect_equal(cursor$fetchedRowCount(), 0)
     expect_equal(cursor$stats(), list(state='INITIAL'))
     expect_true(cursor$hasCompleted())
+    expect_equal(cursor$postResponse(), post.response)
+    expect_true(cursor$postDataParsed())
+    expect_true(cursor$postDataParsed(FALSE))
+    expect_false(cursor$postDataParsed(TRUE))
 
     cursor$state('__TEST')
     expect_equal(cursor$state(), '__TEST')
@@ -74,5 +78,26 @@ test_that('PrestoCursor methods work correctly', {
     expect_equal(cursor$state(), 'FINISHED')
     expect_equal(cursor$fetchedRowCount(), 2)
     expect_is(cursor$stats(), 'list')
+    expect_true(cursor$hasCompleted())
+})
+
+test_that('PrestoCursor methods work correctly with POST data', {
+    response <- mock_httr_response(
+      url='http://localhost:8000/v1/statement',
+      status_code=200,
+      state='FINISHED',
+      data=data.frame(x=1)
+    )[['response']]
+    cursor <- PrestoCursor(response)
+    expect_equal(cursor$infoUri(), '')
+    expect_equal(cursor$nextUri(), '')
+    expect_equal(cursor$state(), 'FINISHED')
+    expect_equal(cursor$fetchedRowCount(), 0)
+    expect_equal(cursor$stats(), list(state='FINISHED'))
+    expect_false(cursor$hasCompleted())
+    expect_equal(cursor$postResponse(), response)
+    expect_false(cursor$postDataParsed())
+    expect_false(cursor$postDataParsed(TRUE))
+    expect_true(cursor$postDataParsed())
     expect_true(cursor$hasCompleted())
 })

--- a/tests/testthat/test-dbSendQuery.R
+++ b/tests/testthat/test-dbSendQuery.R
@@ -184,3 +184,49 @@ test_that('dbSendQuery works with mock - regular', {
     }
   )
 })
+
+test_that('dbSendQuery works with mock - POST data', {
+  conn <- setup_mock_connection()
+  with_mock(
+    `httr::POST`=mock_httr_replies(
+      mock_httr_response(
+        'http://localhost:8000/v1/statement',
+        status_code=200,
+        request_body='SELECT 1 AS x',
+        state='RUNNING',
+        data=data.frame(x=1),
+        next_uri='http://localhost:8000/query_1/1'
+      )
+    ),
+    `httr::GET`=mock_httr_replies(
+      mock_httr_response(
+        'http://localhost:8000/query_1/1',
+        status_code=200,
+        state='FINISHED',
+        data=data.frame()
+      )
+    ),
+    {
+      result <- dbSendQuery(conn, 'SELECT 1 AS x')
+      expect_is(result, 'PrestoResult')
+      expect_equal(result@statement, 'SELECT 1 AS x')
+      expect_equal(result@cursor$fetchedRowCount(), 0)
+      expect_false(result@cursor$hasCompleted())
+      expect_false(result@cursor$postDataParsed())
+      expect_equal_data_frame(
+        dbFetch(result),
+        data.frame(x=1)
+      )
+      expect_true(result@cursor$postDataParsed())
+      expect_false(result@cursor$hasCompleted())
+      expect_equal(result@cursor$fetchedRowCount(), 1)
+      expect_equal_data_frame(
+        dbFetch(result),
+        data.frame()
+      )
+      expect_true(result@cursor$hasCompleted())
+      expect_equal(result@cursor$fetchedRowCount(), 1)
+      expect_true(dbHasCompleted(result))
+    }
+  )
+})


### PR DESCRIPTION
Per the spec in https://github.com/prestodb/presto/wiki/HTTP-Protocol, the POST response can also contain data. This is most evident in the 'SET SESSION' queries. 

So we:
- move the post response storage into the cursor 
- refactor the response parsing 
- refactor the dbFetch logic to first check the data in the post response.