### PR TITLE
Fix dbListFields and duplicate column names

### DIFF
--- a/R/PrestoResult.R
+++ b/R/PrestoResult.R
@@ -5,26 +5,22 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-#' @include utility_functions.R PrestoCursor.R PrestoSession.R
+#' @include utility_functions.R PrestoCursor.R PrestoConnection.R
 NULL
 
 #' An S4 class to represent a Presto Result
-#' @slot post.response The initial response from the HTTP API
 #' @slot statement The SQL statement sent to the database
-#' @slot session.timezone Session time zone used for the connection
+#' @slot connection The connection object associated with the result
 #' @slot cursor An internal implementation detail for keeping track of
 #'  what stage a request is in
-#' @slot session Presto session that is associated with connection. Parameters
-#'  can be updated in place
 #' @keywords internal
 #' @export
 setClass('PrestoResult',
   contains='DBIResult',
   slots=c(
     'statement'='character',
-    'session.timezone'='character',
-    'cursor'='PrestoCursor',
-    'session'='PrestoSession'
+    'connection'='PrestoConnection',
+    'cursor'='PrestoCursor'
   )
 )
 
@@ -53,7 +49,7 @@ setMethod('show',
         ),
         collapse=' / '
       ), '\n',
-      'Session Time Zone: ', object@session.timezone, '\n',
+      'Session Time Zone: ', object@connection@session.timezone, '\n',
       sep=''
     )
   }

--- a/R/dbFetch.R
+++ b/R/dbFetch.R
@@ -72,7 +72,16 @@ NULL
   } else {
     # We need to check for the uniqueness of columns because dplyr::bind_rows
     # will drop duplicate column names and we want to preserve all the data
-    column.names <- names(rv[[1]])
+    unique.chunk.column.names <- unique(lapply(
+      Filter(function(df) NROW(df) || NCOL(df), rv),
+      names
+    ))
+    if (length(unique.chunk.column.names) != 1) {
+      stop('Chunk column names are different across chunks: ',
+        jsonlite::toJSON(lapply(rv, names))
+      )
+    }
+    column.names <- unique.chunk.column.names[[1]]
     if (
       requireNamespace('dplyr', quietly=TRUE) &&
       length(column.names) == length(unique(column.names))

--- a/R/dbSendQuery.R
+++ b/R/dbSendQuery.R
@@ -42,9 +42,8 @@ NULL
       cursor <- PrestoCursor$new(post.response)
       rv <- new('PrestoResult',
         statement=statement,
-        session.timezone=conn@session.timezone,
-        cursor=cursor,
-        session=conn@session
+        connection=conn,
+        cursor=cursor
       )
     }
   } else {

--- a/R/db_query_fields.R
+++ b/R/db_query_fields.R
@@ -8,7 +8,7 @@
 #' @include dbplyr_compatible.R
 NULL
 
-#' S3 implementation of \code{sql_translate_env} for Presto.
+#' S3 implementation of \code{db_query_fields} for Presto.
 #'
 #' @rdname dplyr_function_implementations
 #' @keywords internal
@@ -16,10 +16,9 @@ NULL
 db_query_fields.PrestoConnection <- function(con, sql, ...) {
   build_sql <- dbplyr_compatible('build_sql')
   fields <- build_sql(
-    "SELECT * FROM ", dplyr::sql_subquery(con, sql), " LIMIT 0",
+    "SELECT * FROM ", dplyr::sql_subquery(con, sql), " WHERE 1 = 0",
     con = con
   )
-  result <- dbSendQuery(con, fields)
-  on.exit(dbClearResult(result))
-  return(dbListFields(result))
+  df <- dbGetQuery(con, fields)
+  return(colnames(df))
 }

--- a/R/parse.response.R
+++ b/R/parse.response.R
@@ -31,7 +31,7 @@ NULL
         if (!is.null(properties)) {
           for (pair in strsplit(properties, ',', fixed = TRUE)) {
             pair <- unlist(strsplit(pair, '=', fixed = TRUE))
-            result@session$setParameter(pair[1], pair[2])
+            result@connection@session$setParameter(pair[1], pair[2])
           }
         }
       },
@@ -39,13 +39,13 @@ NULL
         properties <- httr::headers(response)[['x-presto-clear-session']]
         if (!is.null(properties)) {
           for (key in strsplit(properties, ',', fixed = TRUE)) {
-            result@session$unsetParameter(key)
+            result@connection@session$unsetParameter(key)
           }
         }
       }
     )
   }
-  df <- .extract.data(content, timezone=result@session.timezone)
+  df <- .extract.data(content, timezone=result@connection@session.timezone)
   result@cursor$updateCursor(content, NROW(df))
   return(df)
 }

--- a/tests/testthat/test-dbGetQuery.R
+++ b/tests/testthat/test-dbGetQuery.R
@@ -142,3 +142,60 @@ test_that('dbGetQuery works with data in POST response', {
     }
   )
 })
+
+test_that('Inconsistent data in chunks fail', {
+  conn <- setup_mock_connection()
+
+  with_mock(
+    `httr::POST`=mock_httr_replies(
+      mock_httr_response(
+        'http://localhost:8000/v1/statement',
+        status_code=200,
+        state='PLANNING',
+        request_body='SELECT a, b FROM broken_chunks',
+        next_uri='http://localhost:8000/query_1/1'
+      )
+    ),
+    `httr::GET`=mock_httr_replies(
+      mock_httr_response(
+        'http://localhost:8000/query_1/1',
+        status_code=200,
+        state='PLANNING',
+        next_uri='http://localhost:8000/query_1/2'
+      ),
+      mock_httr_response(
+        'http://localhost:8000/query_1/2',
+        status_code=200,
+        state='RUNNING',
+        data=data.frame(a=1, b=TRUE),
+        next_uri='http://localhost:8000/query_1/3'
+      ),
+      mock_httr_response(
+        'http://localhost:8000/query_1/3',
+        status_code=200,
+        state='RUNNING',
+        data=data.frame(x=1, y=TRUE),
+        next_uri='http://localhost:8000/query_1/4'
+      ),
+      mock_httr_response(
+        'http://localhost:8000/query_1/4',
+        status_code=200,
+        state='FINISHED',
+        data=data.frame(a=3, b=FALSE)
+      )
+    ),
+    `httr::DELETE`=mock_httr_replies(
+      mock_httr_response(
+        url='http://localhost:8000/query_1/4',
+        status_code=200,
+        state=''
+      )
+    ),
+    {
+      expect_error(
+        dbGetQuery(conn, 'SELECT a, b FROM broken_chunks'),
+        'Chunk column names are different across chunks'
+      )
+    }
+  )
+})

--- a/tests/testthat/test-dbIsValid.R
+++ b/tests/testthat/test-dbIsValid.R
@@ -27,8 +27,12 @@ test_that('dbIsValid works with live database', {
   expect_error(dbFetch(result))
   expect_false(dbIsValid(result))
 
-  expect_error(
-    dbSendQuery(conn, 'INVALID SQL'),
+  expect_error({
+      result <- dbSendQuery(conn, 'INVALID SQL')
+      while (!dbHasCompleted(result)) {
+        dbFetch(result)
+      }
+    },
     "Query.*failed:.*(no viable alternative at|mismatched) input 'INVALID'"
   )
 })

--- a/tests/testthat/test-dbSendQuery.R
+++ b/tests/testthat/test-dbSendQuery.R
@@ -12,8 +12,12 @@ source('utilities.R')
 test_that('dbSendQuery works with live database', {
   conn <- setup_live_connection()
 
-  expect_error(
-    dbSendQuery(conn, 'INVALID SQL'),
+  expect_error({
+      result <- dbSendQuery(conn, 'INVALID SQL')
+      while (!dbHasCompleted(result)) {
+        dbFetch(result)
+      }
+    },
     "Query.*failed:.*(no viable alternative at|mismatched) input 'INVALID'"
   )
 

--- a/tests/testthat/test-db_query_fields.R
+++ b/tests/testthat/test-db_query_fields.R
@@ -71,7 +71,7 @@ test_that('db_query_fields works with mock', {
         request_body=paste0(
           '^SELECT \\* FROM \\(',
             '\\(SELECT 1 AS a, \'t\' AS b\\) "a"',
-          '\\) "zzz[0-9]+" LIMIT 0$'
+          '\\) "zzz[0-9]+" WHERE 1 = 0$'
         ),
         next_uri='http://localhost:8000/query_1/1'
       ),
@@ -89,7 +89,7 @@ test_that('db_query_fields works with mock', {
         # For dplyr 0.5.0
         request_body=paste0(
           '^SELECT \\* FROM "__non_existent_table__" ',
-          'AS "zzz[0-9]+" LIMIT 0$'
+          'AS "zzz[0-9]+" WHERE 1 = 0$'
         ),
         next_uri='http://localhost:8000/query_2/1',
       ),
@@ -105,7 +105,10 @@ test_that('db_query_fields works with mock', {
         status_code=200,
         state='FINISHED',
         # For dplyr 0.5.0
-        request_body='^SELECT \\* FROM "empty_table" AS "zzz[0-9]+" LIMIT 0$',
+        request_body=paste0(
+          '^SELECT \\* FROM "empty_table" AS "zzz[0-9]+"',
+          ' WHERE 1 = 0$'
+        ),
         next_uri='http://localhost:8000/query_3/1',
       ),
       mock_httr_response(
@@ -120,7 +123,10 @@ test_that('db_query_fields works with mock', {
         status_code=200,
         state='QUEUED',
         # For dplyr 0.5.0
-        request_body='^SELECT \\* FROM "two_columns" AS "zzz[0-9]+" LIMIT 0$',
+        request_body=paste0(
+          '^SELECT \\* FROM "two_columns" AS "zzz[0-9]+"',
+          ' WHERE 1 = 0$'
+        ),
         next_uri='http://localhost:8000/query_4/1',
       )
     ),


### PR DESCRIPTION
Some recent changes to Presto broke our assumptions about column information. We had been assuming the first response would always include that data, which is no longer the case. This PR removes that assumption and adds test cases to verify we are handling the edge cases.