### PR TITLE
Translate `[[` to allow indexing arrays and maps with dplyr

### DIFF
--- a/R/sql_translate_env.R
+++ b/R/sql_translate_env.R
@@ -70,7 +70,7 @@ sql_translate_env.PrestoConnection <- function(con) {
       is.infinite = sql_prefix("IS_FINITE"),
       is.nan = sql_prefix("IS_NAN"),
       `[[` = function(x, i) {
-        i <- dplyr::enexpr(i)
+        i <- substitute(i)
         if (is.character(i)) {
           dbplyr::build_sql(x, "[", dbplyr::escape(i, con = con), "]")
         } else if (is.numeric(i)) {

--- a/R/sql_translate_env.R
+++ b/R/sql_translate_env.R
@@ -77,7 +77,7 @@ sql_translate_env.PrestoConnection <- function(con) {
           # allow syntax like x[1] versus enforcing x[1L]
           dbplyr::build_sql(x, "[", as.integer(i), "]")
         } else {
-          stop("Error: `x` must be character or numeric")
+          stop("Error: `i` must be character or numeric")
         }
       }
     ),

--- a/R/sql_translate_env.R
+++ b/R/sql_translate_env.R
@@ -70,15 +70,10 @@ sql_translate_env.PrestoConnection <- function(con) {
       is.infinite = sql_prefix("IS_FINITE"),
       is.nan = sql_prefix("IS_NAN"),
       `[[` = function(x, i) {
-        i <- substitute(i)
-        if (is.character(i)) {
-          dbplyr::build_sql(x, "[", dbplyr::escape(i, con = con), "]")
-        } else if (is.numeric(i)) {
-          # allow syntax like x[1] versus enforcing x[1L]
-          dbplyr::build_sql(x, "[", as.integer(i), "]")
-        } else {
-          stop("Error: `i` must be character or numeric")
+        if (is.numeric(i) && isTRUE(all.equal(i, as.integer(i)))) {
+          i <- as.integer(i)
         }
+        dbplyr::build_sql(dbplyr::ident_q(x), "[", i, "]")
       }
     ),
     sql_translator(.parent = base_agg,

--- a/R/sql_translate_env.R
+++ b/R/sql_translate_env.R
@@ -68,7 +68,18 @@ sql_translate_env.PrestoConnection <- function(con) {
       pmin = sql_prefix("LEAST"),
       is.finite = sql_prefix("IS_FINITE"),
       is.infinite = sql_prefix("IS_FINITE"),
-      is.nan = sql_prefix("IS_NAN")
+      is.nan = sql_prefix("IS_NAN"),
+      `[[` = function(x, i) {
+        i <- dplyr::enexpr(i)
+        if (is.character(i)) {
+          dbplyr::build_sql(x, "[", dbplyr::escape(i, con = con), "]")
+        } else if (is.numeric(i)) {
+          # allow syntax like x[1] versus enforcing x[1L]
+          dbplyr::build_sql(x, "[", as.integer(i), "]")
+        } else {
+          stop("Error: `x` must be character or numeric")
+        }
+      }
     ),
     sql_translator(.parent = base_agg,
       n = function() sql("COUNT(*)"),

--- a/R/sql_translate_env.R
+++ b/R/sql_translate_env.R
@@ -73,7 +73,7 @@ sql_translate_env.PrestoConnection <- function(con) {
         if (is.numeric(i) && isTRUE(all.equal(i, as.integer(i)))) {
           i <- as.integer(i)
         }
-        dbplyr::build_sql(dbplyr::ident_q(x), "[", i, "]")
+        dbplyr::build_sql(x, "[", i, "]")
       }
     ),
     sql_translator(.parent = base_agg,

--- a/tests/testthat/test-translate_sql.R
+++ b/tests/testthat/test-translate_sql.R
@@ -148,26 +148,26 @@ with_locale(test.locale(), test_that)('`[[` works for char/numeric indices', {
   # a character index should be escaped
   expect_equal(
     translate_sql(x[['a']], con=s[['con']]),
-    dbplyr::build_sql(dbplyr::ident('x'), "['a']", con=s[['con']])
+    dbplyr::sql("\"x\"['a']")
   )
   # but a numeric index (for arrays) should not
   expect_equal(
     translate_sql(x[[1]], con=s[['con']]),
-    dbplyr::build_sql(dbplyr::ident('x'), "[1]", con=s[['con']])
+    dbplyr::sql("\"x\"[1]")
   )
   expect_equal(
     translate_sql(x[[1L]], con=s[['con']]),
-    dbplyr::build_sql(dbplyr::ident('x'), "[1]", con=s[['con']])
+    dbplyr::sql("\"x\"[1]")
   )
 
   # neither `x` nor `i` should be evaluated locally
   expect_equal(
     translate_sql(dim[['a']], con=s[['con']]),
-    dbplyr::build_sql(dbplyr::ident('dim'), "['a']", con=s[['con']])
+    dbplyr::sql("\"dim\"['a']")
   )
   expect_equal(
     translate_sql(x[['dim']], con=s[['con']]),
-    dbplyr::build_sql(dbplyr::ident('x'), "['dim']", con=s[['con']])
+    dbplyr::sql("\"x\"['dim']")
   )
 })
 

--- a/tests/testthat/test-translate_sql.R
+++ b/tests/testthat/test-translate_sql.R
@@ -159,5 +159,16 @@ with_locale(test.locale(), test_that)('subscripting with `[[` works', {
     translate_sql(x[[1L]], con=s[['con']]),
     dbplyr::build_sql(dbplyr::ident('x'), "[1]", con=s[['con']])
   )
+
+  # neither `x` nor `i` should be evaluated locally
+  expect_equal(
+    translate_sql(dim[['a']], con=s[['con']]),
+    dbplyr::build_sql(dbplyr::ident('dim'), "['a']", con=s[['con']])
+  )
+  expect_equal(
+    translate_sql(x[['dim']], con=s[['con']]),
+    dbplyr::build_sql(dbplyr::ident('x'), "['dim']", con=s[['con']])
+  )
+
   expect_error(translate_sql(x[[TRUE]], con=s[['con']]))
 })


### PR DESCRIPTION
Changes:

- Translate `[[` as discussed in #109 
- Add tests for array and map cases

Build/check results:

```
$ R CMD build RPresto
* checking for file ‘RPresto/DESCRIPTION’ ... OK
* preparing ‘RPresto’:
* checking DESCRIPTION meta-information ... OK
* cleaning src
* checking for LF line-endings in source and make files and shell scripts
* checking for empty or unneeded directories
* building ‘RPresto_1.3.2.9000.tar.gz’

$ R CMD check RPresto_1.3.2.9000.tar.gz --as-cran
* using log directory ‘/RPresto.Rcheck’
* using R version 3.5.3 (2019-03-11)
* using platform: x86_64-apple-darwin18.2.0 (64-bit)
* using session charset: UTF-8
* using option ‘--as-cran’
* checking for file ‘RPresto/DESCRIPTION’ ... OK
* this is package ‘RPresto’ version ‘1.3.2.9000’
* package encoding: UTF-8
* checking CRAN incoming feasibility ... NOTE
Maintainer: ‘Onur Ismail Filiz <onur@fb.com>’

Version contains large components (1.3.2.9000)
* checking package namespace information ... OK
* checking package dependencies ... OK
* checking if this is a source package ... OK
* checking if there is a namespace ... OK
* checking for executable files ... OK
* checking for hidden files and directories ... OK
* checking for portable file names ... OK
* checking for sufficient/correct file permissions ... OK
* checking serialization versions ... OK
* checking whether package ‘RPresto’ can be installed ... OK
* checking installed package size ... OK
* checking package directory ... OK
* checking DESCRIPTION meta-information ... OK
* checking top-level files ... NOTE
Files ‘README.md’ or ‘NEWS.md’ cannot be checked without ‘pandoc’ being installed.
* checking for left-over files ... OK
* checking index information ... OK
* checking package subdirectories ... OK
* checking R files for non-ASCII characters ... OK
* checking R files for syntax errors ... OK
* checking whether the package can be loaded ... OK
* checking whether the package can be loaded with stated dependencies ... OK
* checking whether the package can be unloaded cleanly ... OK
* checking whether the namespace can be loaded with stated dependencies ... OK
* checking whether the namespace can be unloaded cleanly ... OK
* checking loading without being on the library search path ... OK
* checking use of S3 registration ... OK
* checking dependencies in R code ... OK
* checking S3 generic/method consistency ... OK
* checking replacement functions ... OK
* checking foreign function calls ... OK
* checking R code for possible problems ... OK
* checking Rd files ... OK
* checking Rd metadata ... OK
* checking Rd line widths ... OK
* checking Rd cross-references ... OK
* checking for missing documentation entries ... OK
* checking for code/documentation mismatches ... OK
* checking Rd \usage sections ... OK
* checking Rd contents ... OK
* checking for unstated dependencies in examples ... OK
* checking line endings in C/C++/Fortran sources/headers ... OK
* checking pragmas in C/C++ headers and code ... OK
* checking compilation flags used ... OK
* checking compiled code ... OK
* checking examples ... OK
* checking for unstated dependencies in ‘tests’ ... OK
* checking tests ...
  Running ‘testthat.R’
 OK
* checking PDF version of manual ... OK
* DONE

Status: 2 NOTEs
```