### PR TITLE
added branch to .fetch.all for a return value of list()

### DIFF
--- a/R/dbFetch.R
+++ b/R/dbFetch.R
@@ -68,7 +68,8 @@ NULL
     rv[[chunk.count]] <- chunk
     chunk.count <- chunk.count + 1
   }
-  if (length(rv) == 1) {
+  if (!length(rv)) return(rv)
+  if (length(rv) <= 1) {
     # Preserve attributes for empty data frames
     return(rv[[1]])
   } else {


### PR DESCRIPTION
Not quite sure what else I'm doing wrong, but the examples:

```
dbGetQuery(con, paste("SELECT * FROM", iris.sql()))
```

Are returning only `list()` for me. This leads to the confusing error:

> Error in .fetch.all(result) : 
  Chunk column names are different across chunks: []

I'm not sure whether it should be an error/warning in this case, but anyway the `length(rv) == 0L` case should be addressed