### PR TITLE
Update cla info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,10 +15,7 @@ package. You can use the 'devtools::check' function to build and verify that
 your changes are working as intended.
 
 ## Contributor License Agreement ("CLA")
-In order to accept your pull request, we need you to submit a CLA. You only need
-to do this once to work on any of Facebook's open source projects.
-
-Complete your CLA here: <https://code.facebook.com/cla>
+In order to accept your pull request, we need you to submit a CLA. You only need to do this once, so if you've done this for one repository in the [prestodb](https://github.com/prestodb) organization, you're good to go. If you are submitting a pull request for the first time, the communitybridge-easycla bot will notify you if you haven't signed, and will provide you with a link.  If you are contributing on behalf of a company, you might want to let the person with manages your corporate CLA whitelist know they will be receiving a request from you.
 
 ## Issues
 We use GitHub issues to track public bugs. Please ensure your description is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ package. You can use the 'devtools::check' function to build and verify that
 your changes are working as intended.
 
 ## Contributor License Agreement ("CLA")
-In order to accept your pull request, we need you to submit a CLA. You only need to do this once, so if you've done this for one repository in the [prestodb](https://github.com/prestodb) organization, you're good to go. If you are submitting a pull request for the first time, the communitybridge-easycla bot will notify you if you haven't signed, and will provide you with a link.  If you are contributing on behalf of a company, you might want to let the person with manages your corporate CLA whitelist know they will be receiving a request from you.
+In order to accept your pull request, we need you to submit a CLA. You only need to do this once, so if you've done this for one repository in the [prestodb](https://github.com/prestodb) organization, you're good to go. If you are submitting a pull request for the first time, the communitybridge-easycla bot will notify you if you haven't signed, and will provide you with a link.  If you are contributing on behalf of a company, you might want to let the person who manages your corporate CLA whitelist know they will be receiving a request from you.
 
 ## Issues
 We use GitHub issues to track public bugs. Please ensure your description is


### PR DESCRIPTION
Update the CONTRIBUTING.md file to remove reference to the Facebook CLA, and instead describe the EasyCLA process.

Signed-off-by: Brian Warner <brian@bdwarner.com>