### PR TITLE
disable translation of quantile() and median()

### DIFF
--- a/R/sql_translate_env.R
+++ b/R/sql_translate_env.R
@@ -20,7 +20,9 @@ presto_window_functions <- function() {
     all=win_recycled('bool_and'),
     any=win_recycled('bool_or'),
     n_distinct=win_absent('n_distinct'),
-    sd=win_recycled("stddev_samp")
+    sd=win_recycled("stddev_samp"),
+    quantile = function(...) stop(quantile_error_msg(), call. = FALSE),
+    median = function(...) stop(quantile_error_msg("median"), call. = FALSE)
   ))
 }
 
@@ -73,15 +75,34 @@ sql_translate_env.PrestoConnection <- function(con) {
           i <- as.integer(i)
         }
         dbplyr::build_sql(x, "[", i, "]")
-      }
+      },
+      quantile = function(...) stop(quantile_error_msg(), call. = FALSE),
+      median = function(...) stop(quantile_error_msg("median"), call. = FALSE)
     ),
     sql_translator(.parent = base_agg,
       n = function() sql("COUNT(*)"),
       sd =  sql_prefix("STDDEV_SAMP"),
       var = sql_prefix("VAR_SAMP"),
       all = sql_prefix("BOOL_AND"),
-      any = sql_prefix("BOOL_OR")
+      any = sql_prefix("BOOL_OR"),
+      quantile = function(...) stop(quantile_error_msg(), call. = FALSE),
+      median = function(...) stop(quantile_error_msg("median"), call. = FALSE)
     ),
     presto_window_functions()
   ))
+}
+
+#' Create error messages for quantile-like functions
+#'
+#' @param f a string giving the name of the function
+#'
+#' @return error message for \code{f}
+#' @keywords internal
+#' @noRd
+quantile_error_msg <- function(f = "quantile") {
+  paste(
+    paste0("`", f, "()`"),
+    "is not supported in this SQL variant,",
+    "try `approx_percentile()` instead; see Presto docs"
+  )
 }

--- a/R/sql_translate_env.R
+++ b/R/sql_translate_env.R
@@ -99,10 +99,10 @@ sql_translate_env.PrestoConnection <- function(con) {
 #' @return error message for \code{f}
 #' @keywords internal
 #' @noRd
-quantile_error_msg <- function(f = "quantile") {
+quantile_error_message <- function(f = "quantile") {
   paste(
     paste0("`", f, "()`"),
     "is not supported in this SQL variant,",
-    "try `approx_percentile()` instead; see Presto docs"
+    "try `approx_percentile()` instead; see Presto documentation."
   )
 }


### PR DESCRIPTION
Changes:

- disable translation of `quantile()` and `median()` as discussed in #119, and suggest `approx_percentile()` instead

- test that attempting to translate `quantile()` or `median()` throws an error

`devtools::check()` results (I have a newer version of `roxygen2`, so the documentation messages can be ignored):

```
> devtools::check()
Updating RPresto documentation
Updating roxygen version in RPresto/DESCRIPTION
Loading RPresto
Writing NAMESPACE
Writing NAMESPACE
Writing Presto.Rd
Writing src_presto.Rd
Writing dplyr_function_implementations.Rd
Writing dbDataType.Rd
Writing dbGetInfo.Rd
Writing RPresto.Rd
── Building ──────────────────────────────────────────────────────────────────────────── RPresto ──
Setting env vars:
● CFLAGS    : -Wall -pedantic -fdiagnostics-color=always
● CXXFLAGS  : -Wall -pedantic -fdiagnostics-color=always
● CXX11FLAGS: -Wall -pedantic -fdiagnostics-color=always
───────────────────────────────────────────────────────────────────────────────────────────────────
✔  checking for file ‘RPresto/DESCRIPTION’ ...
─  preparing ‘RPresto’: (1.2s)
✔  checking DESCRIPTION meta-information ...
─  cleaning src
─  checking for LF line-endings in source and make files and shell scripts
─  checking for empty or unneeded directories
─  building ‘RPresto_1.3.4.9000.tar.gz’
   
── Checking ──────────────────────────────────────────────────────────────────────────── RPresto ──
Setting env vars:
● _R_CHECK_CRAN_INCOMING_REMOTE_: FALSE
● _R_CHECK_CRAN_INCOMING_       : FALSE
● _R_CHECK_FORCE_SUGGESTS_      : FALSE
── R CMD check ────────────────────────────────────────────────────────────────────────────────────
─  using log directory ‘/tmp/RtmpekfL0Z/RPresto.Rcheck’
─  using R version 3.6.1 (2019-07-05)
─  using platform: x86_64-pc-linux-gnu (64-bit)
─  using session charset: UTF-8
─  using options ‘--no-manual --as-cran’
✔  checking for file ‘RPresto/DESCRIPTION’
─  this is package ‘RPresto’ version ‘1.3.4.9000’
─  package encoding: UTF-8
✔  checking package namespace information ...
✔  checking package dependencies (1.3s)
✔  checking if this is a source package
✔  checking if there is a namespace
✔  checking for executable files (458ms)
✔  checking for hidden files and directories
✔  checking for portable file names
✔  checking for sufficient/correct file permissions
✔  checking serialization versions
✔  checking whether package ‘RPresto’ can be installed (13.3s)
✔  checking installed package size ...
✔  checking package directory ...
✔  checking for future file timestamps (859ms)
✔  checking DESCRIPTION meta-information ...
✔  checking top-level files
✔  checking for left-over files
✔  checking index information
✔  checking package subdirectories ...
✔  checking R files for non-ASCII characters ...
✔  checking R files for syntax errors ...
✔  checking whether the package can be loaded ...
✔  checking whether the package can be loaded with stated dependencies ...
✔  checking whether the package can be unloaded cleanly ...
✔  checking whether the namespace can be loaded with stated dependencies ...
✔  checking whether the namespace can be unloaded cleanly ...
✔  checking dependencies in R code (644ms)
✔  checking S3 generic/method consistency (888ms)
✔  checking replacement functions ...
✔  checking foreign function calls (372ms)
✔  checking R code for possible problems (2.8s)
✔  checking Rd files ...
✔  checking Rd metadata ...
✔  checking Rd line widths ...
✔  checking Rd cross-references ...
✔  checking for missing documentation entries ...
✔  checking for code/documentation mismatches (1s)
✔  checking Rd \usage sections (1s)
✔  checking Rd contents ...
✔  checking for unstated dependencies in examples ...
✔  checking line endings in C/C++/Fortran sources/headers
✔  checking pragmas in C/C++ headers and code ...
✔  checking compilation flags used
✔  checking compiled code ...
✔  checking examples (757ms)
✔  checking for unstated dependencies in ‘tests’ ...
─  checking tests ...
✔  Running ‘testthat.R’ (9.7s)
   
   
── R CMD check results ──────────────────────────────────────────────────── RPresto 1.3.4.9000 ────
Duration: 36.9s

0 errors ✔ | 0 warnings ✔ | 0 notes ✔
```