### PR TITLE
Adapt `dbClearResult` to the new uri

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # RPresto 1.3.4.9000
 
 - Add custom Date and POSIXct sql translation implementations for dbplyr (#123, thanks to @OssiLehtinen for original implementations).
+- Adapt `dbClearResult` to the API change, we now need to `DELETE` `/v1/query/<query_id>`.
+- Add a `query.id` slot to `PrestoResult`.
 
 # RPresto 1.3.4
 

--- a/R/dbClearResult.R
+++ b/R/dbClearResult.R
@@ -26,7 +26,11 @@ setMethod('dbClearResult',
     }
 
     headers <- .request_headers(res@connection)
-    delete.result <- httr::DELETE(uri, config=headers)
+    delete.uri <- paste0(
+      res@connection@host, ':', res@connection@port,
+      '/v1/query/', res@query.id
+    )
+    delete.result <- httr::DELETE(delete.uri, config=headers)
     s <- httr::status_code(delete.result)
     if (s >= 200 && s < 300) {
       res@cursor$state('__KILLED')

--- a/tests/testthat/test-dbClearResult.R
+++ b/tests/testthat/test-dbClearResult.R
@@ -23,30 +23,33 @@ test_that('dbClearResult works with mock', {
         status_code=200,
         state='QUEUED',
         request_body='SELECT 1',
-        next_uri='http://localhost:8000/query_1/1'
+        next_uri='http://localhost:8000/query_1/1',
+        query_id='query_1'
       ),
       mock_httr_response(
         url='http://localhost:8000/v1/statement',
         status_code=200,
         state='QUEUED',
         request_body='SELECT 2',
-        next_uri='http://localhost:8000/query_2/1'
+        next_uri='http://localhost:8000/query_2/1',
+        query_id='query_2'
       ),
       mock_httr_response(
         url='http://localhost:8000/v1/statement',
         status_code=200,
         state='FINISHED',
-        request_body='SELECT 3'
+        request_body='SELECT 3',
+        query_id='query_3'
       )
     ),
     `httr::DELETE`=mock_httr_replies(
       mock_httr_response(
-        url='http://localhost:8000/query_1/1',
+        url='http://localhost:8000/v1/query/query_1',
         status_code=200,
         state=''
       ),
       mock_httr_response(
-        url='http://localhost:8000/query_2/1',
+        url='http://localhost:8000/v1/query/query_2',
         status_code=500,
         state=''
       )

--- a/tests/testthat/test-dbFetch.R
+++ b/tests/testthat/test-dbFetch.R
@@ -41,7 +41,8 @@ test_that('dbFetch works with mock', {
         state='QUEUED',
         request_body=
           '^SELECT n FROM \\(VALUES \\(1\\), \\(2\\)\\) AS t \\(n\\)$',
-        next_uri='http://localhost:8000/query_1/1'
+        next_uri='http://localhost:8000/query_1/1',
+        query_id='query_1'
       ),
       mock_httr_response(
         'http://localhost:8000/v1/statement',
@@ -100,7 +101,7 @@ test_that('dbFetch works with mock', {
     ),
     `httr::DELETE`=mock_httr_replies(
       mock_httr_response(
-        url='http://localhost:8000/query_1/2',
+        url='http://localhost:8000/v1/query/query_1',
         status_code=200,
         state=''
       )

--- a/tests/testthat/test-dbGetQuery.R
+++ b/tests/testthat/test-dbGetQuery.R
@@ -152,7 +152,8 @@ test_that('Inconsistent data in chunks fail', {
         status_code=200,
         state='PLANNING',
         request_body='SELECT a, b FROM broken_chunks',
-        next_uri='http://localhost:8000/query_1/1'
+        next_uri='http://localhost:8000/query_1/1',
+        query_id='query_1'
       )
     ),
     `httr::GET`=mock_httr_replies(
@@ -185,7 +186,7 @@ test_that('Inconsistent data in chunks fail', {
     ),
     `httr::DELETE`=mock_httr_replies(
       mock_httr_response(
-        url='http://localhost:8000/query_1/4',
+        url='http://localhost:8000/v1/query/query_1',
         status_code=200,
         state=''
       )

--- a/tests/testthat/test-dbIsValid.R
+++ b/tests/testthat/test-dbIsValid.R
@@ -207,30 +207,33 @@ test_that('dbIsValid works with mock - dbClearResult', {
         status_code=200,
         state='QUEUED',
         request_body='SELECT 1',
-        next_uri='http://localhost:8000/query_1/1'
+        next_uri='http://localhost:8000/query_1/1',
+        query_id='query_1'
       ),
       mock_httr_response(
         url='http://localhost:8000/v1/statement',
         status_code=200,
         state='QUEUED',
         request_body='SELECT 2',
-        next_uri='http://localhost:8000/query_2/1'
+        next_uri='http://localhost:8000/query_2/1',
+        query_id='query_2'
       ),
       mock_httr_response(
         url='http://localhost:8000/v1/statement',
         status_code=200,
         state='FINISHED',
-        request_body='SELECT 3'
+        request_body='SELECT 3',
+        query_id='query_3'
       )
     ),
     `httr::DELETE`=mock_httr_replies(
       mock_httr_response(
-        url='http://localhost:8000/query_1/1',
+        url='http://localhost:8000/v1/query/query_1',
         status_code=200,
         state=''
       ),
       mock_httr_response(
-        url='http://localhost:8000/query_2/1',
+        url='http://localhost:8000/v1/query/query_2',
         status_code=500,
         state=''
       )

--- a/tests/testthat/test-dbListFields.R
+++ b/tests/testthat/test-dbListFields.R
@@ -44,7 +44,8 @@ test_that('dbListFields works with mock - PrestoConnection', {
         status_code=200,
         state='QUEUED',
         request_body='SELECT \\* FROM "__non_existent_table__" LIMIT 0',
-        next_uri='http://localhost:8000/query_2/1'
+        next_uri='http://localhost:8000/query_2/1',
+        query_id='query_2'
       )
     ),
     `httr::GET`=mock_httr_replies(
@@ -66,7 +67,7 @@ test_that('dbListFields works with mock - PrestoConnection', {
     ),
     `httr::DELETE`=mock_httr_replies(
       mock_httr_response(
-        url='http://localhost:8000/query_2/1',
+        url='http://localhost:8000/v1/query/query_2',
         status_code=200,
         state=''
       )
@@ -107,14 +108,16 @@ test_that('dbListFields works with mock - PrestoResult', {
           '^SELECT \\* FROM \\(SELECT \\* FROM __non_existent_table__\\) ',
           'WHERE 1 = 0$'
         ),
-        next_uri='http://localhost:8000/query_4/1'
+        next_uri='http://localhost:8000/query_4/1',
+        query_id='query_4'
       ),
       mock_httr_response(
         'http://localhost:8000/v1/statement',
         status_code=200,
         state='FINISHED',
         request_body='SELECT \\* FROM empty_table',
-        next_uri='http://localhost:8000/query_3/1'
+        next_uri='http://localhost:8000/query_3/1',
+        query_id='query_4'
       ),
       mock_httr_response(
         'http://localhost:8000/v1/statement',
@@ -131,7 +134,8 @@ test_that('dbListFields works with mock - PrestoResult', {
           '^SELECT \\* FROM \\(SELECT \\* FROM three_columns\\) ',
           'WHERE 1 = 0$'
         ),
-        next_uri='http://localhost:8000/query_6/1'
+        next_uri='http://localhost:8000/query_6/1',
+        query_id='query_6'
       )
     ),
     `httr::GET`=mock_httr_replies(
@@ -185,17 +189,17 @@ test_that('dbListFields works with mock - PrestoResult', {
     ),
     `httr::DELETE`=mock_httr_replies(
       mock_httr_response(
-        url='http://localhost:8000/query_3/1',
+        url='http://localhost:8000/v1/query_3',
         status_code=200,
         state=''
       ),
       mock_httr_response(
-        url='http://localhost:8000/query_4/1',
+        url='http://localhost:8000/v1/query/query_4',
         status_code=200,
         state=''
       ),
       mock_httr_response(
-        url='http://localhost:8000/query_6/2',
+        url='http://localhost:8000/v1/query/query_6',
         status_code=200,
         state=''
       )

--- a/tests/testthat/test-db_query_fields.R
+++ b/tests/testthat/test-db_query_fields.R
@@ -60,7 +60,8 @@ test_that('db_query_fields works with mock', {
           '\\(\\(SELECT 1 AS a, \'t\' AS b\\) AS "a"\\) ',
           'AS "zzz[0-9]+" LIMIT 0$'
         ),
-        next_uri='http://localhost:8000/query_1/1'
+        next_uri='http://localhost:8000/query_1/1',
+        query_id='query_1'
       ),
       mock_httr_response(
         'http://localhost:8000/v1/statement',
@@ -72,7 +73,8 @@ test_that('db_query_fields works with mock', {
             '\\(SELECT 1 AS a, \'t\' AS b\\) "a"',
           '\\) "zzz[0-9]+" WHERE 1 = 0$'
         ),
-        next_uri='http://localhost:8000/query_1/1'
+        next_uri='http://localhost:8000/query_1/1',
+        query_id='query_1'
       ),
       mock_httr_response(
         'http://localhost:8000/v1/statement',
@@ -84,7 +86,8 @@ test_that('db_query_fields works with mock', {
             '\\(SELECT 1 AS a, \'t\' AS b\\) "a"',
           '\\) "q[0-9]+" WHERE 1 = 0$'
         ),
-        next_uri='http://localhost:8000/query_1/1'
+        next_uri='http://localhost:8000/query_1/1',
+        query_id='query_1'
       ),
       mock_httr_response(
         'http://localhost:8000/v1/statement',
@@ -203,7 +206,7 @@ test_that('db_query_fields works with mock', {
     ),
     `httr::DELETE`=function(url, body, ...) {
       mock_httr_response(
-        url='http://localhost:8000/query_1/1',
+        url='http://localhost:8000/v1/query/query_1',
         status_code=200,
         state=''
       )[['response']]


### PR DESCRIPTION
We now need to `DELETE` `/v1/query/<query_id>`.