### PR TITLE
Fix testing errors caused by Presto changes since last update.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RPresto
 Title: DBI Connector to Presto
-Version: 1.3.6
+Version: 1.3.6.9000
 Authors@R: c(
     person('Onur Ismail', 'Filiz', , 'onur@fb.com', role='aut'),
     person('Sergey', 'Goder', , 'sgoder@fb.com', role='aut'),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# RPresto 1.3.6.9000
+
+# Fix testing errors caused by Presto changes since last update (#131)
+
 # RPresto 1.3.6
 
 - Change maintainer to Thomas Leeper (thomasleeper@fb.com)

--- a/tests/testthat/test-data_types.R
+++ b/tests/testthat/test-data_types.R
@@ -23,7 +23,7 @@ test_that("Queries return the correct primitive types", {
                data_frame(bool = TRUE))
   expect_equal_data_frame(dbGetQuery(conn, "select 1 one"),
                data_frame(one = 1))
-  expect_equal_data_frame(dbGetQuery(conn, "select 1.0 one"),
+  expect_equal_data_frame(dbGetQuery(conn, "select cast(1 as double) one"),
                data_frame(one = 1.0))
   expect_equal_data_frame(dbGetQuery(conn, "select 'one' one"),
                data_frame(one = 'one'))
@@ -155,7 +155,7 @@ test_that("all data types work", {
     type_array_bigint=NA,
     type_map_varchar_bigint=NA
   )
-  attr(e[['type_timestamp_with_timezone']], 'tzone') <- NULL
+  attr(e[['type_timestamp_with_timezone']], 'tzone') <- ""
   attr(e[['type_timestamp']], 'tzone') <- test.timezone()
   e[['type_varbinary']] <- list(NA)
   e[['type_array_bigint']] <- list(NA)

--- a/tests/testthat/test-dplyr.integration.R
+++ b/tests/testthat/test-dplyr.integration.R
@@ -37,15 +37,15 @@ test_that('dplyr integration works', {
   )
 
   iris_presto_summary <- as.data.frame(dplyr::collect(
-    dplyr::rename(
-      dplyr::arrange(
+    dplyr::arrange(
+      dplyr::rename(
         dplyr::summarise(
           dplyr::group_by(iris_presto, species),
           mean_sepal_length = mean(as(sepal_length, 0.0), na.rm=TRUE)
         ),
-        species
+        Species=species
       ),
-      Species=species
+      Species
     ),
     n=Inf
   ))


### PR DESCRIPTION
1) ORDER BY (translated by dplyr::arrange()) doesn't work in subqueries. test-dplyr.integration.R is modified so that arrange() is the outmost operation.
2) Literals like 1.0 is now being treated as DECIMAL type in Presto and DECIMAL is translated to character rather than numeric. test-data_types.R is modified to explicitly cast the double literal to a double type.

Fixes most of the issued raised in #130 except the ones caused by `MAP()[key]` now throwing error when `key` is not present rather than returning NULL.