### PR TITLE
Change the `[[` implementation for MAP from `[` operator to `ELEMENT_AT()` function

### DIFF
--- a/R/sql_translate_env.R
+++ b/R/sql_translate_env.R
@@ -72,7 +72,7 @@ sql_translate_env.PrestoConnection <- function(con) {
         if (is.numeric(i) && isTRUE(all.equal(i, as.integer(i)))) {
           i <- as.integer(i)
         }
-        dbplyr::build_sql(x, "[", i, "]")
+        dbplyr::build_sql("ELEMENT_AT(", x, ", ", i, ")")
       }
     ),
     sql_translator(.parent = base_agg,

--- a/tests/testthat/test-translate_sql.R
+++ b/tests/testthat/test-translate_sql.R
@@ -177,26 +177,26 @@ with_locale(test.locale(), test_that)('`[[` works for char/numeric indices', {
   # a character index should be escaped
   expect_equal(
     translate_sql(x[['a']], con=s[['con']]),
-    dbplyr::sql("\"x\"['a']")
+    dbplyr::sql("ELEMENT_AT(\"x\", 'a')")
   )
   # but a numeric index (for arrays) should not
   expect_equal(
     translate_sql(x[[1]], con=s[['con']]),
-    dbplyr::sql("\"x\"[1]")
+    dbplyr::sql("ELEMENT_AT(\"x\", 1)")
   )
   expect_equal(
     translate_sql(x[[1L]], con=s[['con']]),
-    dbplyr::sql("\"x\"[1]")
+    dbplyr::sql("ELEMENT_AT(\"x\", 1)")
   )
 
   # neither `x` nor `i` should be evaluated locally
   expect_equal(
     translate_sql(dim[['a']], con=s[['con']]),
-    dbplyr::sql("\"dim\"['a']")
+    dbplyr::sql("ELEMENT_AT(\"dim\", 'a')")
   )
   expect_equal(
     translate_sql(x[['dim']], con=s[['con']]),
-    dbplyr::sql("\"x\"['dim']")
+    dbplyr::sql("ELEMENT_AT(\"x\", 'dim')")
   )
 })
 


### PR DESCRIPTION
This is more consistent with the intended behavior (evident from how the unit tests on MAP were written).

I updated the literal SQL translation test cases because the Presto-side implementation has changed.

This fixes #132 .