### PR TITLE
Enable simple ROW support 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,8 @@ Imports:
     stringi,
     stats,
     Rcpp (>= 0.12.7),
-    utils
+    utils,
+    purrr
 Suggests:
     testthat,
     dplyr (>= 0.7.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 - Fix testing errors caused by Presto changes since last update (#131)
 - Change `[[` translation from `[]` subscript operator to `ELEMENT_AT()` (#132)
+- Enable simple ROW type support (#137)
 
 # RPresto 1.3.6
 

--- a/R/dbDataType.R
+++ b/R/dbDataType.R
@@ -29,6 +29,7 @@ NULL
   'interval day to second', 'character',
   'array', 'list_unnamed',
   'map', 'list_named',
+  'row', 'list_named',
   'unknown', 'unknown'
 ), byrow=TRUE, ncol=2), stringsAsFactors=FALSE)
 colnames(.presto.to.R) <- c('presto.type', 'R.type')

--- a/tests/testthat/test-data_types.R
+++ b/tests/testthat/test-data_types.R
@@ -72,6 +72,38 @@ test_that("Queries return the correct map types", {
                e)
 })
 
+test_that("Queries return the correct row types", {
+  conn <- setup_live_connection()
+  e <- data_frame(r = NA)
+  e[[1]] <- list(list(x = 1))
+  expect_equal_data_frame(
+    dbGetQuery(conn, "select cast(row(1) as row(x bigint)) r"),
+    e
+  )
+  e[[1]] <- list(list(x = 1, y = "a"))
+  expect_equal_data_frame(
+    dbGetQuery(
+      conn,
+      "select cast(row(1, 'a') as row(x bigint, y varchar)) r"
+    ),
+    e
+  )
+  e <- data_frame(r = rep(NA, 2))
+  e[[1]] <- list(list(x = 1L, y = "a"), list(x = 2L, y = "b"))
+  expect_equal_data_frame(
+    dbGetQuery(
+      conn,
+      "
+        select cast(row(1, 'a') as row(x bigint, y varchar)) r
+        union all
+        select cast(row(2, 'b') as row(x bigint, y varchar)) r
+        order by r.x
+      "
+    ),
+    e
+  )
+})
+
 test_that("all data types work", {
   conn <- setup_live_connection(session.timezone=test.timezone())
   e <- data_frame(


### PR DESCRIPTION
Enable simple ROW support by translating a ROW column in Presto to a list-column of named lists (very similar to MAP) in R.

Unlike MAP, the subfield names are not transmitted in the data JSON, so we need to grab the subfield names from the schema JSON and manually set them for any ROW columns.

I added  unit tests in test-data_types.R to ensure the translation works as intended.

All tests passed locally.

```
==> Rcpp::compileAttributes()

* Updated src/RcppExports.cpp
* Updated R/RcppExports.R

==> Sourcing R files in 'tests' directory

══ Skipped tests ═══════════════════════════════════════════════════════════════
• non utf8 locale (2)

[ FAIL 0 | WARN 0 | SKIP 2 | PASS 440 ]

Tests complete
```

This PR alleviates #118 .