### PR TITLE
Fix a mismatched parenthesis error in DESCRIPTION Authors section

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,6 +10,8 @@ Authors@R: c(
         role=c('ctb', 'cre')
     ),
     person('John Myles', 'White', , 'johnmyleswhite@fb.com', role='ctb')
+    ),
+    person('Jarod G.R.', 'Meng', , 'jarodm@fb.com', role='ctb')
     )
 Copyright: Facebook, Inc. 2015-present.
 Description: Implements a 'DBI' compliant interface to Presto. Presto is

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,8 +9,7 @@ Authors@R: c(
         'thomasleeper@fb.com',
         role=c('ctb', 'cre')
     ),
-    person('John Myles', 'White', , 'johnmyleswhite@fb.com', role='ctb')
-    ),
+    person('John Myles', 'White', , 'johnmyleswhite@fb.com', role='ctb'),
     person('Jarod G.R.', 'Meng', , 'jarodm@fb.com', role='ctb')
     )
 Copyright: Facebook, Inc. 2015-present.


### PR DESCRIPTION
The small error prevents a user from installing the package, so should be fixed asap.