### PR TITLE
Fix is.infinite() translation from IS_FINITE() to IS_INFINITE()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 - Fix testing errors caused by Presto changes since last update (#131)
 - Change `[[` translation from `[]` subscript operator to `ELEMENT_AT()` (#132)
 - Enable simple ROW type support (#137)
+* Fix a bug whereby `is.infinite()` is incorrectly translated to `IS_FINITE()`
+  instead of `IS_INFINITE()` in SQL (#139)
 
 # RPresto 1.3.6
 

--- a/R/sql_translate_env.R
+++ b/R/sql_translate_env.R
@@ -66,7 +66,7 @@ sql_translate_env.PrestoConnection <- function(con) {
       pmax = sql_prefix("GREATEST"),
       pmin = sql_prefix("LEAST"),
       is.finite = sql_prefix("IS_FINITE"),
-      is.infinite = sql_prefix("IS_FINITE"),
+      is.infinite = sql_prefix("IS_INFINITE"),
       is.nan = sql_prefix("IS_NAN"),
       `[[` = function(x, i) {
         if (is.numeric(i) && isTRUE(all.equal(i, as.integer(i)))) {

--- a/tests/testthat/test-translate_sql.R
+++ b/tests/testthat/test-translate_sql.R
@@ -332,3 +332,25 @@ with_locale(test.locale(), test_that)('`[[` works for dynamic indices', {
     c("map_2", NA)
   )
 })
+
+with_locale(test.locale(), test_that)('is.[in]finite() works', {
+  if (!requireNamespace('dplyr', quietly=TRUE)) {
+    skip('dplyr not available')
+  }
+
+  translate_sql <- RPresto:::dbplyr_compatible('translate_sql')
+  translate_sql_ <- RPresto:::dbplyr_compatible('translate_sql_')
+
+  s <- setup_mock_dplyr_connection()[['db']]
+
+  expect_equal(
+    translate_sql(is.infinite(x), con = s$con),
+    dplyr::sql("IS_INFINITE(\"x\")")
+  )
+
+  expect_equal(
+    translate_sql(is.finite(x), con = s$con),
+    dplyr::sql("IS_FINITE(\"x\")")
+  )
+})
+


### PR DESCRIPTION
This PR fixes #139.

All tests passed locally

```
==> Rcpp::compileAttributes()

* Updated R/RcppExports.R

==> Sourcing R files in 'tests' directory

══ Skipped tests ═══════════════════════════════════════════════════════════════
• non utf8 locale (2)

[ FAIL 0 | WARN 0 | SKIP 2 | PASS 442 ]

Tests complete
```