### PR TITLE
Support Trino headers in session

### DIFF
--- a/R/PrestoConnection.R
+++ b/R/PrestoConnection.R
@@ -21,6 +21,7 @@ setClass('PrestoConnection',
     'port'='integer',
     'source'='character',
     'session.timezone'='character',
+    'use.trino.headers'='logical',
     'Id'='character',
     'session'='PrestoSession'
   )

--- a/R/dbConnect.R
+++ b/R/dbConnect.R
@@ -44,6 +44,7 @@ setMethod('dbConnect',
     source = getPackageName(),
     session.timezone='UTC',
     parameters = list(),
+    use.trino.headers=FALSE,
     ...
   ) {
     port <- suppressWarnings(as.integer(port))
@@ -59,6 +60,7 @@ setMethod('dbConnect',
       port=port,
       source=source,
       session.timezone=session.timezone,
+      use.trino.headers=use.trino.headers,
       session=PrestoSession$new(parameters)
     )
     return(conn)

--- a/R/request_headers.R
+++ b/R/request_headers.R
@@ -5,6 +5,17 @@
 # LICENSE file in the root directory of this source tree.
 
 .request_headers <- function(conn) {
+  if (isTRUE(conn@use.trino.headers)) {
+    return(httr::add_headers(
+      "X-Trino-User"= conn@user,
+      "X-Trino-Catalog"= conn@catalog,
+      "X-Trino-Schema"= conn@schema,
+      "X-Trino-Source"= conn@source,
+      "X-Trino-Time-Zone" = conn@session.timezone,
+      "User-Agent"= getPackageName(),
+      "X-Trino-Session"=conn@session$parameterString()
+    ))
+  }
   return(httr::add_headers(
     "X-Presto-User"= conn@user,
     "X-Presto-Catalog"= conn@catalog,

--- a/README.md
+++ b/README.md
@@ -87,6 +87,27 @@ iris %>%
   collect()
 ```
 
+## Connecting to Trino
+
+To connect to Trino you must set the `use.trino.headers` parameter so `RPresto`
+knows to send the correct headers to the server. Otherwise all the same
+functionality is supported.
+
+```R
+library('DBI')
+
+con <- dbConnect(
+  RPresto::Presto(),
+  use.trino.headers=TRUE,
+  host='http://localhost',
+  port=7777,
+  user=Sys.getenv('USER'),
+  schema='<schema>',
+  catalog='<catalog>',
+  source='<source>'
+)
+```
+
 ## How RPresto works
 
 Presto exposes its interface via a REST based API<sup>1</sup>. We utilize the


### PR DESCRIPTION
Trino is basically the same as Presto but the headers we need to send
for auth are different. Here we add a new session param to use the
correct headers which resolves #143