### PR TITLE
Fix documentation and unit tests for the newly added use.trino.headers argument

### DIFF
--- a/man/Presto.Rd
+++ b/man/Presto.Rd
@@ -18,6 +18,7 @@ Presto(...)
   source = getPackageName(),
   session.timezone = "UTC",
   parameters = list(),
+  use.trino.headers = FALSE,
   ...
 )
 

--- a/tests/testthat/utilities.R
+++ b/tests/testthat/utilities.R
@@ -346,7 +346,6 @@ setup_live_dplyr_connection <- function(session.timezone) {
     session.timezone <- ''
   }
   db <- src_presto(
-    RPresto::Presto(),
     schema=credentials$schema,
     catalog=credentials$catalog,
     host=credentials$host,
@@ -378,7 +377,6 @@ setup_mock_dplyr_connection <- function() {
     skip("Skipping dplyr tests because we can't load dplyr")
   }
   db <- src_presto(
-    RPresto::Presto(),
     schema='test',
     catalog='catalog',
     host='http://localhost',


### PR DESCRIPTION
`dbConnect.PrestoConnection()` recently gained a `use.trino.headers` argument. This PR 1) adds the argument to the documentation and 2) removes unused and redundant  argument value from `src_presto()` calls in `setup_live_dplyr_connection()` and `setup_mock_dplyr_connection()` because the redundant arg is matching the newly added use.trino.headers argument and causes unit tests to fail.