### PR TITLE
Fix src_presto documentations

### DIFF
--- a/R/src.presto.R
+++ b/R/src.presto.R
@@ -20,11 +20,18 @@
 #'   database connector \code{dbConnect}. For \code{tbl.src_presto}, it is
 #'   included for compatibility with the generic, but otherwise ignored.
 #' @export
+#' @name src_presto
 #' @examples
 #' \dontrun{
 #' # To connect to a database
-#' my_db <- src_presto(catalog = "hive", schema = "web", user = "onur",
-#'   host = "localhost", port = 8888, session.timezone='Asia/Kathmandu')
+#' my_db <- src_presto(
+#'   catalog = "memory",
+#'   schema = "default",
+#'   user = Sys.getenv("USER"),
+#'   host = "http://localhost",
+#'   port = 8080,
+#'   session.timezone = "Asia/Kathmandu"
+#' )
 #' }
 src_presto <- function(
     catalog=NULL,

--- a/R/tbl.src.presto.R
+++ b/R/tbl.src.presto.R
@@ -19,8 +19,8 @@ NULL
 #'   \code{\link[dplyr]{sql}} described a derived table or compound join.
 #' @examples
 #' \dontrun{
-#' First create a database connection with src_presto, then reference a tbl
-#' within that database
+#' # First create a database connection with src_presto, then reference a tbl
+#' # within that database
 #' my_tbl <- tbl(my_db, "my_table")
 #' }
 #' @rdname src_presto

--- a/man/src_presto.Rd
+++ b/man/src_presto.Rd
@@ -56,12 +56,18 @@ administrator for the values of these variables.
 \examples{
 \dontrun{
 # To connect to a database
-my_db <- src_presto(catalog = "hive", schema = "web", user = "onur",
-  host = "localhost", port = 8888, session.timezone='Asia/Kathmandu')
+my_db <- src_presto(
+  catalog = "memory",
+  schema = "default",
+  user = Sys.getenv("USER"),
+  host = "http://localhost",
+  port = 8080,
+  session.timezone = "Asia/Kathmandu"
+)
 }
 \dontrun{
-First create a database connection with src_presto, then reference a tbl
-within that database
+# First create a database connection with src_presto, then reference a tbl
+# within that database
 my_tbl <- tbl(my_db, "my_table")
 }
 }


### PR DESCRIPTION
1) Add missing @name tag for @rdname to work
2) Use `Sys.getenv("USER")` instead of plain user name in @examples
3) Fix the commenting error in the @examples tag of `tbl.src_presto()`