### PR TITLE
Add use.trino.headers @param documentation

### DIFF
--- a/R/dbConnect.R
+++ b/R/dbConnect.R
@@ -20,6 +20,8 @@ NULL
 #'          zone. See the session.timezone tests for examples.
 #' @param parameters A \code{\link{list}} of extra parameters to be passed in
 #'          the \sQuote{X-Presto-Session} header
+#' @param use.trino.headers A boolean to indicate whether Trino request headers
+#'          should be used. Default to FALSE.
 #' @param ... currently ignored
 #' @return [dbConnect] A \code{\linkS4class{PrestoConnection}} object
 #' @export

--- a/man/Presto.Rd
+++ b/man/Presto.Rd
@@ -49,6 +49,9 @@ zone. See the session.timezone tests for examples.}
 \item{parameters}{A \code{\link{list}} of extra parameters to be passed in
 the \sQuote{X-Presto-Session} header}
 
+\item{use.trino.headers}{A boolean to indicate whether Trino request headers
+should be used. Default to FALSE.}
+
 \item{conn}{A \code{\linkS4class{PrestoConnection}} object}
 }
 \value{


### PR DESCRIPTION
`dbConnect.PrestoConnection()` recently gained a `use.trino.headers` argument, but the corresponding @param documentation is missing. It causes `R CMD check` to give a warning.