### PR TITLE
Support passing Extra Credentials through X-Presto-Extra-Credential or X-Trino-Extra-Credential 

### DIFF
--- a/R/PrestoConnection.R
+++ b/R/PrestoConnection.R
@@ -23,7 +23,8 @@ setClass('PrestoConnection',
     'session.timezone'='character',
     'use.trino.headers'='logical',
     'Id'='character',
-    'session'='PrestoSession'
+    'session'='PrestoSession',
+    'extra.credentials'='character'
   )
 )
 
@@ -39,6 +40,7 @@ setMethod('show',
       'User: ', object@user, '\n',
       'Source: ', object@source, '\n',
       'Session Time Zone: ', object@session.timezone, '\n',
+      'Extra Credentials: ', object@extra.credentials, '\n',
       sep=''
     )
     parameters <- object@session$parameters()

--- a/R/dbConnect.R
+++ b/R/dbConnect.R
@@ -47,6 +47,7 @@ setMethod('dbConnect',
     session.timezone='UTC',
     parameters = list(),
     use.trino.headers=FALSE,
+    extra.credentials="",
     ...
   ) {
     port <- suppressWarnings(as.integer(port))
@@ -63,7 +64,8 @@ setMethod('dbConnect',
       source=source,
       session.timezone=session.timezone,
       use.trino.headers=use.trino.headers,
-      session=PrestoSession$new(parameters)
+      session=PrestoSession$new(parameters),
+      extra.credentials=extra.credentials
     )
     return(conn)
   }

--- a/R/request_headers.R
+++ b/R/request_headers.R
@@ -13,7 +13,8 @@
       "X-Trino-Source"= conn@source,
       "X-Trino-Time-Zone" = conn@session.timezone,
       "User-Agent"= getPackageName(),
-      "X-Trino-Session"=conn@session$parameterString()
+      "X-Trino-Session"=conn@session$parameterString(),
+      "X-Trino-Extra-Credential"=conn@extra.credentials
     ))
   }
   return(httr::add_headers(
@@ -23,6 +24,7 @@
     "X-Presto-Source"= conn@source,
     "X-Presto-Time-Zone" = conn@session.timezone,
     "User-Agent"= getPackageName(),
-    "X-Presto-Session"=conn@session$parameterString()
+    "X-Presto-Session"=conn@session$parameterString(),
+    "X-Presto-Extra-Credential"=conn@extra.credentials
   ))
 }

--- a/README.md
+++ b/README.md
@@ -108,6 +108,30 @@ con <- dbConnect(
 )
 ```
 
+## Passing Extra Credentials to the Connector
+
+To pass extraCredentials that gets added to the `X-Presto-Extra-Credential` header
+use the `extra.credentials` parameter so `RPresto` will add that to the header while
+creating the PrestoConnection.
+
+Set `use.trino.headers` if you want to pass extraCredentials through the
+`X-Trino-Extra-Credential` header.
+
+```R
+library('DBI')
+
+con <- dbConnect(
+  RPresto::Presto(),
+  host='http://localhost',
+  port=7777,
+  user=Sys.getenv('USER'),
+  schema='<schema>',
+  catalog='<catalog>',
+  source='<source>',
+  extra.credentials="test.token.foo=bar",
+)
+```
+
 ## How RPresto works
 
 Presto exposes its interface via a REST based API<sup>1</sup>. We utilize the

--- a/tests/testthat/test-extra.credential.R
+++ b/tests/testthat/test-extra.credential.R
@@ -1,0 +1,15 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+context('extra.credentials')
+
+source('utilities.R')
+
+test_that('extra.credentials should be set in the connection as a string', {
+
+  conn <- setup_live_connection(extra.credentials="test.token.foo=bar")
+  expect_equal(conn@extra.credentials, 'test.token.foo=bar')
+})

--- a/tests/testthat/utilities.R
+++ b/tests/testthat/utilities.R
@@ -312,7 +312,7 @@ read_credentials <- function() {
   return(credentials)
 }
 
-setup_live_connection <- function(session.timezone, parameters) {
+setup_live_connection <- function(session.timezone, parameters, extra.credentials="", ...) {
   skip_on_cran()
   credentials <- read_credentials()
   if (missing(session.timezone)) {
@@ -329,6 +329,7 @@ setup_live_connection <- function(session.timezone, parameters) {
     source=credentials$source,
     session.timezone=session.timezone,
     parameters=parameters,
+    extra.credentials=extra.credentials,
     user=Sys.getenv('USER')
   )
   return(conn)


### PR DESCRIPTION
Currently,  There is support for passing in ONLY Session properties ( through `X-Presto-Session` header) and there is no support for passing extraCredentials (through `X-Presto-Extra-Credential` header) that are connector specific.