### PR TITLE
Add a title for PrestoSession documentation and add an "internal" tag

### DIFF
--- a/R/PrestoSession.R
+++ b/R/PrestoSession.R
@@ -4,9 +4,15 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+#' Class to encapsulate a Presto session
+#' 
 #' Internal implementation detail class needed for its side-effects.
 #' When SET/RESET SESSION queries are called, session parameters need to be
 #' maintained by the client and requires an in-place update.
+#'
+#' @slot .parameters List of Presto session parameters to be added to the
+#'         X-Presto-Session header.
+#' @keywords internal
 PrestoSession <- setRefClass('PrestoSession',
   fields=c(
     '.parameters'

--- a/man/PrestoSession-class.Rd
+++ b/man/PrestoSession-class.Rd
@@ -4,12 +4,18 @@
 \name{PrestoSession-class}
 \alias{PrestoSession-class}
 \alias{PrestoSession}
-\title{Internal implementation detail class needed for its side-effects.
-When SET/RESET SESSION queries are called, session parameters need to be
-maintained by the client and requires an in-place update.}
+\title{Class to encapsulate a Presto session}
 \description{
 Internal implementation detail class needed for its side-effects.
 When SET/RESET SESSION queries are called, session parameters need to be
 maintained by the client and requires an in-place update.
 }
+\section{Slots}{
 
+\describe{
+\item{\code{.parameters}}{List of Presto session parameters to be added to the
+X-Presto-Session header.}
+}}
+
+
+\keyword{internal}


### PR DESCRIPTION
A very small commit to improve PrestoSession class documentation and make it internal (so that it doesn't show up in Reference when running pkgdown).