### PR TITLE
Improve documentations

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,4 @@
 ^\.travis\.yml$
 ^CRAN-RELEASE$
 ^backend-implementations.md
+^README\.Rmd$

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,0 +1,244 @@
+---
+output: github_document
+---
+
+<!-- README.md is generated from README.Rmd. Please edit that file -->
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.path = "man/figures/README-",
+  out.width = "100%"
+)
+```
+
+# RPresto
+
+<!-- badges: start -->
+<!-- badges: end -->
+
+RPresto is a [DBI](https://dbi.r-dbi.org/)-based adapter for
+the open source distributed SQL query engine [Presto](https://prestodb.io/)
+for running interactive analytic queries.
+
+## Installation
+
+RPresto is both on [CRAN](https://cran.r-project.org/package=RPresto)
+and [github](https://github.com/prestodb/RPresto).
+
+For the CRAN version, you can use
+
+```{r install_cran, eval = FALSE}
+install.packages("RPresto")
+```
+
+You can install the development version of RPresto from
+[GitHub](https://github.com/) with:
+
+```{r install_github, eval = FALSE}
+# install.packages("devtools")
+devtools::install_github("prestodb/RPresto")
+```
+
+## Usage
+
+**The following examples assume that you have a in-memory Presto server set up
+locally.** It's the simplest server which stores all data and metadata in RAM on
+workers and both are discarded when Presto restarts. If you don't have one set
+up, please refer to the [memory connector documentation][1].
+
+```{r setup, eval = TRUE}
+# Load libaries and connect to Presto
+library(RPresto)
+library(DBI)
+
+con <- DBI::dbConnect(
+  drv = RPresto::Presto(),
+  host = "http://localhost",
+  port = 8080,
+  user = Sys.getenv("USER"),
+  catalog = "memory",
+  schema = "default"
+)
+```
+
+There are two levels of APIs: `DBI` and `dplyr`.
+
+### `DBI` APIs
+
+The easiest and most flexible way of executing a `SELECT` query is using a
+[`dbGetQuery()`][2] call. It returns the query result in a [`tibble`][3].
+
+```{r dbGetQuery, eval=TRUE}
+DBI::dbGetQuery(con, "SELECT CAST(3.14 AS DOUBLE) AS pi")
+```
+
+[`dbWriteTable()`][4] can be used to write a small data frame into a Presto
+table.
+
+```{r dbWriteTable_pre_hook, eval = TRUE, echo = FALSE}
+if (DBI::dbExistsTable(con, "mtcars")) {
+  DBI::dbRemoveTable(con, "mtcars")
+}
+```
+
+```{r dbWriteTable, eval = TRUE}
+# Writing mtcars data frame into Presto
+DBI::dbWriteTable(con, "mtcars", mtcars)
+```
+
+[`dbExistsTable()`][5] checks if a table exists.
+
+```{r dbExistsTable, eval = TRUE}
+DBI::dbExistsTable(con, "mtcars")
+```
+
+[`dbReadTable()`][6] reads the entire table into R. It's essentially a `SELECT *`
+query on the table.
+
+```{r dbReadTable, eval = TRUE}
+DBI::dbReadTable(con, "mtcars")
+```
+
+[`dbRemoveTable()`][7] drops the table from Presto.
+
+```{r dbRemoveTable, eval = TRUE}
+DBI::dbRemoveTable(con, "mtcars")
+```
+
+You can execute a statement and returns the number of rows affected using
+[`dbExecute()`][8].
+
+```{r dbExecute_1_pre_hook, eval = TRUE, echo = FALSE}
+if (DBI::dbExistsTable(con, "testing_table")) {
+  DBI::dbRemoveTable(con, "testing_table")
+}
+```
+
+```{r dbExecute_1, eval = TRUE}
+# Create an empty table using CREATE TABLE
+DBI::dbExecute(
+  con, "CREATE TABLE testing_table (field1 BIGINT, field2 VARCHAR)"
+)
+```
+
+`dbExecute()` returns the number of rows affected by the statement. Since a
+`CREATE TABLE` statement creates an empty table, it returns 0.
+
+```{r dbExecute_2, eval = TRUE}
+DBI::dbExecute(
+  con,
+  "INSERT INTO testing_table VALUES (1, 'abc'), (2, 'xyz')"
+)
+```
+
+Since 2 rows are inserted into the table, it returns 2.
+
+```{r check_dbExecute, eval = TRUE}
+# Check the previous INSERT statment works
+DBI::dbReadTable(con, "testing_table")
+```
+
+### `dplyr` APIs
+
+We also include `dplyr` database backend integration (which is mainly
+implemented using the [`dbplyr` package][9]).
+
+```{r dplyr_setup, eval = TRUE, message = FALSE}
+# Load packages
+library(dplyr)
+library(dbplyr)
+
+# Add iris to Presto
+if (!DBI::dbExistsTable(con, "iris")) {
+  DBI::dbWriteTable(con, "iris", iris)
+}
+```
+
+[`dplyr::tbl()`][10] can work directly on `PrestoConnection` object.
+
+```{r dplyr_tbl, eval = TRUE}
+# Treat "iris" in Presto as a remote data source that dplyr can now manipulate
+tbl.iris <- dplyr::tbl(con, "iris")
+
+# colnames() gives the column names
+tbl.iris %>% colnames()
+
+# dplyr verbs can be applied onto the remote data source
+tbl.iris %>%
+  group_by(species) %>%
+  summarize(
+    mean_sepal_length = mean(sepal.length, na.rm = TRUE)
+  ) %>%
+  arrange(species) %>%
+  collect()
+```
+
+## Connecting to Trino
+
+To connect to Trino you must set the `use.trino.headers` parameter so `RPresto`
+knows to send the correct headers to the server. Otherwise all the same
+functionality is supported.
+
+```{r, eval=FALSE}
+con.trino <- DBI::dbConnect(
+  RPresto::Presto(),
+  use.trino.headers=TRUE,
+  host="http://localhost",
+  port=7777,
+  user=Sys.getenv("USER"),
+  schema="<schema>",
+  catalog="<catalog>",
+  source="<source>"
+)
+```
+
+## Passing extra credentials to the connector
+
+To pass extraCredentials that gets added to the `X-Presto-Extra-Credential`
+header use the `extra.credentials` parameter so `RPresto` will add that to the
+header while creating the `PrestoConnection`.
+
+Set `use.trino.headers` if you want to pass extraCredentials through the
+`X-Trino-Extra-Credential` header.
+
+```{r, eval=FALSE}
+con <- DBI::dbConnect(
+  RPresto::Presto(),
+  host="http://localhost",
+  port=7777,
+  user=Sys.getenv("USER"),
+  schema="<schema>",
+  catalog="<catalog>",
+  source="<source>",
+  extra.credentials="test.token.foo=bar",
+)
+```
+
+## How RPresto works
+
+Presto exposes its interface via a REST based API[^1]. We utilize the
+[httr](https://github.com/r-lib/httr) package to make the API calls and
+use [jsonlite](https://github.com/jeroen/jsonlite) to reshape the
+data into a `tibble`. Note that as of now, only read operations are
+supported.
+
+RPresto has been tested on Presto 0.100.
+
+## License
+RPresto is BSD-licensed.
+
+[^1]: See <https://github.com/prestodb/presto/wiki/HTTP-Protocol> for a
+description of the API.
+
+[1]: https://prestodb.io/docs/current/connector/memory.html
+[2]: https://dbi.r-dbi.org/reference/dbgetquery
+[3]: https://tibble.tidyverse.org/
+[4]: https://dbi.r-dbi.org/reference/dbwritetable
+[5]: https://dbi.r-dbi.org/reference/dbexiststable
+[6]: https://dbi.r-dbi.org/reference/dbreadtable
+[7]: https://dbi.r-dbi.org/reference/dbremovetable
+[8]: https://dbi.r-dbi.org/reference/dbexecute
+[9]: https://dbplyr.tidyverse.org/
+[10]: https://dplyr.tidyverse.org/reference/tbl.html

--- a/README.md
+++ b/README.md
@@ -1,149 +1,250 @@
+
+<!-- README.md is generated from README.Rmd. Please edit that file -->
+
 # RPresto
 
-RPresto is a [DBI](https://github.com/r-dbi/DBI)-based adapter for
-the open source distributed SQL query engine [Presto](https://prestodb.io/)
-for running interactive analytic queries.
+<!-- badges: start -->
+<!-- badges: end -->
+
+RPresto is a [DBI](https://dbi.r-dbi.org/)-based adapter for the open
+source distributed SQL query engine [Presto](https://prestodb.io/) for
+running interactive analytic queries.
 
 ## Installation
 
 RPresto is both on [CRAN](https://cran.r-project.org/package=RPresto)
 and [github](https://github.com/prestodb/RPresto).
+
 For the CRAN version, you can use
 
-```R
-install.packages('RPresto')
+``` r
+install.packages("RPresto")
 ```
 
-You can install the github development version via
+You can install the development version of RPresto from
+[GitHub](https://github.com/) with:
 
-```R
-devtools::install_github('prestodb/RPresto')
+``` r
+# install.packages("devtools")
+devtools::install_github("prestodb/RPresto")
 ```
 
-## Examples
+## Usage
 
-The standard DBI approach works with RPresto:
+**The following examples assume that you have a in-memory Presto server
+set up locally.** It’s the simplest server which stores all data and
+metadata in RAM on workers and both are discarded when Presto restarts.
+If you don’t have one set up, please refer to the [memory connector
+documentation](https://prestodb.io/docs/current/connector/memory.html).
 
-```R
-library('DBI')
+``` r
+# Load libaries and connect to Presto
+library(RPresto)
+library(DBI)
 
-con <- dbConnect(
-  RPresto::Presto(),
-  host='http://localhost',
-  port=7777,
-  user=Sys.getenv('USER'),
-  schema='<schema>',
-  catalog='<catalog>',
-  source='<source>'
+con <- DBI::dbConnect(
+  drv = RPresto::Presto(),
+  host = "http://localhost",
+  port = 8080,
+  user = Sys.getenv("USER"),
+  catalog = "memory",
+  schema = "default"
 )
-
-res <- dbSendQuery(con, 'SELECT 1')
-# dbFetch without arguments only returns the current chunk, so we need to
-# loop until the query completes.
-while (!dbHasCompleted(res)) {
-    chunk <- dbFetch(res)
-    print(chunk)
-}
-
-res <- dbSendQuery(con, 'SELECT CAST(NULL AS VARCHAR)')
-# Due to the unpredictability of chunk sizes with presto, we do not support
-# custom number of rows
-# testthat::expect_error(dbFetch(res, 5))
-
-# To get all rows using dbFetch, pass in a -1 argument
-print(dbFetch(res, -1))
-
-# An alternative is to use dbGetQuery directly
-
-# `source` for iris.sql()
-source(system.file('tests', 'testthat', 'utilities.R', package='RPresto'))
-
-iris <- dbGetQuery(con, paste("SELECT * FROM", iris.sql()))
-
-dbDisconnect(con)
 ```
 
-We also include [dplyr](https://github.com/tidyverse/dplyr) integration.
+There are two levels of APIs: `DBI` and `dplyr`.
 
-```R
+### `DBI` APIs
+
+The easiest and most flexible way of executing a `SELECT` query is using
+a [`dbGetQuery()`](https://dbi.r-dbi.org/reference/dbgetquery) call. It
+returns the query result in a [`tibble`](https://tibble.tidyverse.org/).
+
+``` r
+DBI::dbGetQuery(con, "SELECT CAST(3.14 AS DOUBLE) AS pi")
+#> # A tibble: 1 × 1
+#>      pi
+#>   <dbl>
+#> 1  3.14
+```
+
+[`dbWriteTable()`](https://dbi.r-dbi.org/reference/dbwritetable) can be
+used to write a small data frame into a Presto table.
+
+``` r
+# Writing mtcars data frame into Presto
+DBI::dbWriteTable(con, "mtcars", mtcars)
+```
+
+[`dbExistsTable()`](https://dbi.r-dbi.org/reference/dbexiststable)
+checks if a table exists.
+
+``` r
+DBI::dbExistsTable(con, "mtcars")
+#> [1] TRUE
+```
+
+[`dbReadTable()`](https://dbi.r-dbi.org/reference/dbreadtable) reads the
+entire table into R. It’s essentially a `SELECT *` query on the table.
+
+``` r
+DBI::dbReadTable(con, "mtcars")
+#> # A tibble: 32 × 11
+#>      mpg   cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb
+#>    <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
+#>  1  21       6  160    110  3.9   2.62  16.5     0     1     4     4
+#>  2  21       6  160    110  3.9   2.88  17.0     0     1     4     4
+#>  3  22.8     4  108     93  3.85  2.32  18.6     1     1     4     1
+#>  4  21.4     6  258    110  3.08  3.22  19.4     1     0     3     1
+#>  5  18.7     8  360    175  3.15  3.44  17.0     0     0     3     2
+#>  6  18.1     6  225    105  2.76  3.46  20.2     1     0     3     1
+#>  7  14.3     8  360    245  3.21  3.57  15.8     0     0     3     4
+#>  8  24.4     4  147.    62  3.69  3.19  20       1     0     4     2
+#>  9  22.8     4  141.    95  3.92  3.15  22.9     1     0     4     2
+#> 10  19.2     6  168.   123  3.92  3.44  18.3     1     0     4     4
+#> # … with 22 more rows
+```
+
+[`dbRemoveTable()`](https://dbi.r-dbi.org/reference/dbremovetable) drops
+the table from Presto.
+
+``` r
+DBI::dbRemoveTable(con, "mtcars")
+```
+
+You can execute a statement and returns the number of rows affected
+using [`dbExecute()`](https://dbi.r-dbi.org/reference/dbexecute).
+
+``` r
+# Create an empty table using CREATE TABLE
+DBI::dbExecute(
+  con, "CREATE TABLE testing_table (field1 BIGINT, field2 VARCHAR)"
+)
+#> [1] 0
+```
+
+`dbExecute()` returns the number of rows affected by the statement.
+Since a `CREATE TABLE` statement creates an empty table, it returns 0.
+
+``` r
+DBI::dbExecute(
+  con,
+  "INSERT INTO testing_table VALUES (1, 'abc'), (2, 'xyz')"
+)
+#> [1] 2
+```
+
+Since 2 rows are inserted into the table, it returns 2.
+
+``` r
+# Check the previous INSERT statment works
+DBI::dbReadTable(con, "testing_table")
+#> # A tibble: 2 × 2
+#>   field1 field2
+#>    <int> <chr> 
+#> 1      1 abc   
+#> 2      2 xyz
+```
+
+### `dplyr` APIs
+
+We also include `dplyr` database backend integration (which is mainly
+implemented using the [`dbplyr`
+package](https://dbplyr.tidyverse.org/)).
+
+``` r
+# Load packages
 library(dplyr)
+library(dbplyr)
 
-db <- src_presto(
-  host='http://localhost',
-  port=7777,
-  user=Sys.getenv('USER'),
-  schema='<schema>',
-  catalog='<catalog>',
-  source='<source>'
-)
+# Add iris to Presto
+if (!DBI::dbExistsTable(con, "iris")) {
+  DBI::dbWriteTable(con, "iris", iris)
+}
+```
 
-# Assuming you have a table like iris in the database
-iris <- tbl(db, 'iris')
+[`dplyr::tbl()`](https://dplyr.tidyverse.org/reference/tbl.html) can
+work directly on `PrestoConnection` object.
 
-iris %>%
+``` r
+# Treat "iris" in Presto as a remote data source that dplyr can now manipulate
+tbl.iris <- dplyr::tbl(con, "iris")
+
+# colnames() gives the column names
+tbl.iris %>% colnames()
+#> [1] "sepal.length" "sepal.width"  "petal.length" "petal.width"  "species"
+
+# dplyr verbs can be applied onto the remote data source
+tbl.iris %>%
   group_by(species) %>%
-  summarise(mean_sepal_length = mean(as(sepal_length, 0.0))) %>%
+  summarize(
+    mean_sepal_length = mean(sepal.length, na.rm = TRUE)
+  ) %>%
   arrange(species) %>%
   collect()
+#> # A tibble: 3 × 2
+#>   species    mean_sepal_length
+#>   <chr>                  <dbl>
+#> 1 setosa                  5.01
+#> 2 versicolor              5.94
+#> 3 virginica               6.59
 ```
 
 ## Connecting to Trino
 
-To connect to Trino you must set the `use.trino.headers` parameter so `RPresto`
-knows to send the correct headers to the server. Otherwise all the same
-functionality is supported.
+To connect to Trino you must set the `use.trino.headers` parameter so
+`RPresto` knows to send the correct headers to the server. Otherwise all
+the same functionality is supported.
 
-```R
-library('DBI')
-
-con <- dbConnect(
+``` r
+con.trino <- DBI::dbConnect(
   RPresto::Presto(),
   use.trino.headers=TRUE,
-  host='http://localhost',
+  host="http://localhost",
   port=7777,
-  user=Sys.getenv('USER'),
-  schema='<schema>',
-  catalog='<catalog>',
-  source='<source>'
+  user=Sys.getenv("USER"),
+  schema="<schema>",
+  catalog="<catalog>",
+  source="<source>"
 )
 ```
 
-## Passing Extra Credentials to the Connector
+## Passing extra credentials to the connector
 
-To pass extraCredentials that gets added to the `X-Presto-Extra-Credential` header
-use the `extra.credentials` parameter so `RPresto` will add that to the header while
-creating the PrestoConnection.
+To pass extraCredentials that gets added to the
+`X-Presto-Extra-Credential` header use the `extra.credentials` parameter
+so `RPresto` will add that to the header while creating the
+`PrestoConnection`.
 
 Set `use.trino.headers` if you want to pass extraCredentials through the
 `X-Trino-Extra-Credential` header.
 
-```R
-library('DBI')
-
-con <- dbConnect(
+``` r
+con <- DBI::dbConnect(
   RPresto::Presto(),
-  host='http://localhost',
+  host="http://localhost",
   port=7777,
-  user=Sys.getenv('USER'),
-  schema='<schema>',
-  catalog='<catalog>',
-  source='<source>',
+  user=Sys.getenv("USER"),
+  schema="<schema>",
+  catalog="<catalog>",
+  source="<source>",
   extra.credentials="test.token.foo=bar",
 )
 ```
 
 ## How RPresto works
 
-Presto exposes its interface via a REST based API<sup>1</sup>. We utilize the
+Presto exposes its interface via a REST based API[^1]. We utilize the
 [httr](https://github.com/r-lib/httr) package to make the API calls and
-use [jsonlite](https://github.com/jeroen/jsonlite) to reshape the
-data into a `tibble`. Note that as of now, only read operations are
+use [jsonlite](https://github.com/jeroen/jsonlite) to reshape the data
+into a `tibble`. Note that as of now, only read operations are
 supported.
 
 RPresto has been tested on Presto 0.100.
 
 ## License
+
 RPresto is BSD-licensed.
 
-[1] See <https://github.com/prestodb/presto/wiki/HTTP-Protocol> for a
-description of the API.
+[^1]: See <https://github.com/prestodb/presto/wiki/HTTP-Protocol> for a
+    description of the API.

--- a/backend-implementations.md
+++ b/backend-implementations.md
@@ -22,6 +22,11 @@ The required DBI classes are defined in the following files. Their specific DBI
   * The `dbExistsTable()` method is implemented in `dbExistsTable.R`.
   * The `dbGetQuery()` method is implemented in `dbGetQuery.R`.
   * The `dbListTables()` method is implemented in `dbListTables.R`.
+  * The `dbCreateTable()` method is implemented in `sqlCreateTable.R` and
+    `dbCreateTable.R`.
+  * The `dbCreateTableAs()` method is implemented in `sqlCreateTableAs.R` and
+    `dbCreateTableAs.R`.
+  * The `dbWriteTable()` method is implemented in `dbWriteTable.R`.
 * `PrestoResult`: `PrestoResult.R`
   * The `dbSendQuery()` method is implemented in `dbSendQuery.R`.
   * The `dbClearResult()` method is implemented in `dbClearResult.R`.
@@ -61,11 +66,13 @@ around a DBI database connection object (i.e. `PrestoConnection`).
 * The `dplyr::copy_to()` method is explicitly not implemented in
 `copy.to.src.presto.R`.
 * The `dplyr::tbl()` method is implemented in `tbl.src.presto.R`.
+* The `dplyr::collect()` method is implemented in `src.presto.R`.
 
 The `dplyr` database backend also relies on implementation of a few `dbplyr`
 methods.
 * The `dbplyr::dbplyr_edition()` method is implemented in
   `dbplyr.edition.PrestoConnection.R`.
+* The `dbplyr::db_collect()` method is implemented in `db_collect.R`.
 * The `dbplyr::sql_escape_date()` method is implemented in
   `sql_escape_date.R`.
 * The `dbplyr::sql_escape_datetime()` method is implemented in


### PR DESCRIPTION
* Add `dbWriteTable()` documentation in the implementation doc.
* Use README.Rmd to enable a richer and more automated introduction documentation.
* Modify the README to include up-to-date RPresto APIs.