### PR TITLE
Change dbWriteTable() row.names argument's default value

### DIFF
--- a/R/dbWriteTable.R
+++ b/R/dbWriteTable.R
@@ -18,7 +18,7 @@ NULL
 .dbWriteTable <- function(
   conn, name, value,
   overwrite = FALSE, ...,
-  append = FALSE, field.types = NULL, temporary = FALSE, row.names = NA
+  append = FALSE, field.types = NULL, temporary = FALSE, row.names = FALSE
 ) {
   stopifnot(
     length(overwrite) == 1 &&
@@ -36,7 +36,7 @@ NULL
   if (!identical(temporary, FALSE)) {
     stop('Temporary tables not supported by RPresto', call. = FALSE)
   }
-  if (!is.na(row.names)) {
+  if (!identical(row.names, FALSE)) {
     stop('row.names not supported by RPresto', call. = FALSE)
   }
 

--- a/man/PrestoConnection-class.Rd
+++ b/man/PrestoConnection-class.Rd
@@ -61,7 +61,7 @@
   append = FALSE,
   field.types = NULL,
   temporary = FALSE,
-  row.names = NA
+  row.names = FALSE
 )
 
 \S4method{sqlCreateTable}{PrestoConnection}(


### PR DESCRIPTION
Change dbWriteTable() row.names argument's default value to FALSE to match the default values passed down by db_write_table() and copy_to()