### PR TITLE
Fix dbExistsTable() error when quoted identifier instead of character is supplied

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@ more robust mapping between Presto data types and R types
     They are now translated to typed vectors, lists, or tibbles depending on the
     types and structure of the data. (#118)
 * Add vignettes on Presto-R type translations
+* `dbExistsTable()` error when quoted identifier is supplied as `name` is fixed
+  (#167)
 
 # RPresto 1.3.8
 

--- a/R/dbExistsTable.R
+++ b/R/dbExistsTable.R
@@ -13,6 +13,10 @@ NULL
 setMethod('dbExistsTable',
   c('PrestoConnection', 'character'),
   function(conn, name, ...) {
-    return(tolower(name) %in% tolower(dbListTables(conn, pattern=name)))
+    # This is necessary because name might be a quoted identifier rather than
+    # just a string (see #167)
+    name = DBI::dbQuoteIdentifier(conn, name)
+    id = DBI::dbUnquoteIdentifier(conn, name)[[1]]@name
+    return(tolower(id) %in% tolower(dbListTables(conn, pattern=id)))
   }
 )

--- a/tests/testthat/test-dbExistsTable.R
+++ b/tests/testthat/test-dbExistsTable.R
@@ -49,5 +49,8 @@ test_that('dbExistsTable works with mock', {
     {
       expect_false(dbExistsTable(conn, '_non_existent_table_'))
       expect_true(dbExistsTable(conn, 'existing_table'))
+      expect_true(
+        dbExistsTable(conn, dbQuoteIdentifier(conn, 'existing_table'))
+      )
     })
 })


### PR DESCRIPTION
Unquote identifier to get the table name before passing it to dbListTables() in the dbExistsTable() implementation. Fixing #167 