### PR TITLE
Modify how dbExistsTable() is implemented

### DIFF
--- a/tests/testthat/test-dbExistsTable.R
+++ b/tests/testthat/test-dbExistsTable.R
@@ -12,46 +12,8 @@ test_that('dbExistsTable works with live database', {
   conn <- setup_live_connection()
   expect_false(dbExistsTable(conn, '_non_existent_table_'))
   expect_false(db_has_table(conn, '_non_existent_table_'))
-})
-
-test_that('dbExistsTable works with mock', {
-  conn <- setup_mock_connection()
-  with_mock(
-    `httr::POST`=mock_httr_replies(
-      mock_httr_response(
-        'http://localhost:8000/v1/statement',
-        status_code=200,
-        state='QUEUED',
-        request_body="SHOW TABLES LIKE '_non_existent_table_'",
-        next_uri='http://localhost:8000/query_1/1'
-      ),
-      mock_httr_response(
-        'http://localhost:8000/v1/statement',
-        status_code=200,
-        state='QUEUED',
-        request_body="SHOW TABLES LIKE 'existing_table'",
-        next_uri='http://localhost:8000/query_2/1'
-      )
-    ),
-    `httr::GET`=mock_httr_replies(
-      mock_httr_response(
-        'http://localhost:8000/query_1/1',
-        status_code=200,
-        data=data.frame(Table='', stringsAsFactors=FALSE)[FALSE, ],
-        state='FINISHED'
-      ),
-      mock_httr_response(
-        'http://localhost:8000/query_2/1',
-        status_code=200,
-        data=data.frame(Table='existing_table', stringsAsFactors=FALSE),
-        state='FINISHED'
-      )
-    ),
-    {
-      expect_false(dbExistsTable(conn, '_non_existent_table_'))
-      expect_true(dbExistsTable(conn, 'existing_table'))
-      expect_true(
-        dbExistsTable(conn, dbQuoteIdentifier(conn, 'existing_table'))
-      )
-    })
+  expect_true(dbExistsTable(conn, 'iris'))
+  expect_true(db_has_table(conn, 'iris'))
+  expect_true(dbExistsTable(conn, dbQuoteIdentifier(conn, 'iris')))
+  expect_true(db_has_table(conn, dbQuoteIdentifier(conn, 'iris')))
 })


### PR DESCRIPTION
Modify how dbExistsTable() is implemented from using dbListTables() which hangs when used on a large catalog to leveraging the faster db_query_fields() method.