### PR TITLE
Allow users to pass extra request config to PrestoConnection and use them in GET/POST

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,8 @@ more robust mapping between Presto data types and R types
   * `dplyr::tbl()` method for `PrestoConnection`
   * `dbplyr::db_compute()`
   * `dplyr::compute()`
+* `PrestoConnection` gains a `request.config` slot whereby users can set extra
+  Curl configs (as returned by `httr::config()` to GET/POST requests. (#173)
 
 # RPresto 1.3.8
 

--- a/R/PrestoConnection.R
+++ b/R/PrestoConnection.R
@@ -7,6 +7,10 @@
 #' @include PrestoSession.R
 NULL
 
+# Register request as a valid S3 class so that it can be used to specify the
+# request.config slot in PrestoConnection below.
+setOldClass('request')
+
 #' S4 implementation of \code{DBIConnection} for Presto.
 #'
 #' @keywords internal
@@ -25,6 +29,7 @@ setClass('PrestoConnection',
     'use.trino.headers'='logical',
     'Id'='character',
     'session'='PrestoSession',
+    'request.config'='request',
     'extra.credentials'='character',
     'bigint'='character'
   )

--- a/R/dbConnect.R
+++ b/R/dbConnect.R
@@ -20,6 +20,8 @@ NULL
 #'          zone. See the session.timezone tests for examples.
 #' @param parameters A \code{\link{list}} of extra parameters to be passed in
 #'          the \sQuote{X-Presto-Session} header
+#' @param request.config An optional config list, as returned by
+#'          `httr::config()`, to be sent with every HTTP request.
 #' @param use.trino.headers A boolean to indicate whether Trino request headers
 #'          should be used. Default to FALSE.
 #' @param extra.credentials Extra credentials to be passed in the
@@ -60,6 +62,7 @@ setMethod('dbConnect',
     source = methods::getPackageName(),
     session.timezone='UTC',
     parameters = list(),
+    request.config = httr::config(),
     use.trino.headers=FALSE,
     extra.credentials="",
     bigint = c("integer", "integer64", "numeric", "character"),
@@ -78,6 +81,7 @@ setMethod('dbConnect',
       port=port,
       source=source,
       session.timezone=session.timezone,
+      request.config=request.config,
       use.trino.headers=use.trino.headers,
       session=PrestoSession$new(parameters),
       extra.credentials=extra.credentials,

--- a/R/request_headers.R
+++ b/R/request_headers.R
@@ -6,7 +6,7 @@
 
 .request_headers <- function(conn) {
   if (isTRUE(conn@use.trino.headers)) {
-    return(httr::add_headers(
+    headers <- httr::add_headers(
       "X-Trino-User"= conn@user,
       "X-Trino-Catalog"= conn@catalog,
       "X-Trino-Schema"= conn@schema,
@@ -15,16 +15,19 @@
       "User-Agent"= methods::getPackageName(),
       "X-Trino-Session"=conn@session$parameterString(),
       "X-Trino-Extra-Credential"=conn@extra.credentials
-    ))
+    )
+  } else {
+    headers <- httr::add_headers(
+      "X-Presto-User"= conn@user,
+      "X-Presto-Catalog"= conn@catalog,
+      "X-Presto-Schema"= conn@schema,
+      "X-Presto-Source"= conn@source,
+      "X-Presto-Time-Zone" = conn@session.timezone,
+      "User-Agent"= methods::getPackageName(),
+      "X-Presto-Session"=conn@session$parameterString(),
+      "X-Presto-Extra-Credential"=conn@extra.credentials
+    )
   }
-  return(httr::add_headers(
-    "X-Presto-User"= conn@user,
-    "X-Presto-Catalog"= conn@catalog,
-    "X-Presto-Schema"= conn@schema,
-    "X-Presto-Source"= conn@source,
-    "X-Presto-Time-Zone" = conn@session.timezone,
-    "User-Agent"= methods::getPackageName(),
-    "X-Presto-Session"=conn@session$parameterString(),
-    "X-Presto-Extra-Credential"=conn@extra.credentials
-  ))
+  request_combine <- utils::getFromNamespace('request_combine', 'httr')
+  return(request_combine(headers, conn@request.config))
 }

--- a/man/Presto.Rd
+++ b/man/Presto.Rd
@@ -18,6 +18,7 @@ Presto(...)
   source = methods::getPackageName(),
   session.timezone = "UTC",
   parameters = list(),
+  request.config = httr::config(),
   use.trino.headers = FALSE,
   extra.credentials = "",
   bigint = c("integer", "integer64", "numeric", "character"),
@@ -50,6 +51,9 @@ zone. See the session.timezone tests for examples.}
 
 \item{parameters}{A \code{\link{list}} of extra parameters to be passed in
 the \sQuote{X-Presto-Session} header}
+
+\item{request.config}{An optional config list, as returned by
+\code{httr::config()}, to be sent with every HTTP request.}
 
 \item{use.trino.headers}{A boolean to indicate whether Trino request headers
 should be used. Default to FALSE.}

--- a/tests/testthat/test-dbConnect.R
+++ b/tests/testthat/test-dbConnect.R
@@ -81,6 +81,21 @@ test_that('dbConnect constructs PrestoConnection correctly', {
     'character'
   )
 
+  expect_true(
+    dbConnect(
+      RPresto::Presto(),
+      catalog='jmx',
+      schema='test',
+      host='http://localhost',
+      port=8000,
+      source='testsource',
+      session.timezone=test.timezone(),
+      user=Sys.getenv('USER'),
+      bigint='character',
+      request.config=httr::verbose()
+    )@request.config$options$verbose
+  )
+
   expect_error(
     dbConnect(
       RPresto::Presto(),


### PR DESCRIPTION
Add a request.config slot to PrestoConnection to allow users to set extra HTTP request config options via httr::config(). The configs are used in POST and GET in PrestoQuery.

This PR doesn't change existing APIs.

All unit tests passed and R CMD CHECK returns no error/note/warning.