### PR TITLE
Make primitive and complex type translations work for Trino

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ more robust mapping between Presto data types and R types
   * Add complete support for complex Presto types (i.e., ARRAY, MAP, and ROW).
     They are now translated to typed vectors, lists, or tibbles depending on the
     types and structure of the data. (#118)
+  * It supports all primitive and complex data types for Trino too. (#176)
 * Add vignettes on Presto-R type translations (see `vignette("primitive-types")`
   and `vignette("complex-types")`)
 * `dbExistsTable()` error when quoted identifier is supplied as `name` is fixed

--- a/tests/testthat/utilities.R
+++ b/tests/testthat/utilities.R
@@ -339,22 +339,42 @@ setup_live_connection <- function(session.timezone = "",
                                   parameters = list(),
                                   extra.credentials = "",
                                   bigint = c("integer", "integer64", "numeric", "character"),
-                                  ...) {
+                                  ...,
+                                  type = "Presto") {
   skip_on_cran()
-  credentials <- read_credentials()
-  conn <- dbConnect(RPresto::Presto(),
-    schema = credentials$schema,
-    catalog = credentials$catalog,
-    host = credentials$host,
-    port = credentials$port,
-    source = credentials$source,
-    session.timezone = session.timezone,
-    parameters = parameters,
-    extra.credentials = extra.credentials,
-    user = Sys.getenv("USER"),
-    bigint = bigint,
-    ...
-  )
+  if (type == "Presto") {
+    credentials <- read_credentials()
+    conn <- dbConnect(RPresto::Presto(),
+      schema = credentials$schema,
+      catalog = credentials$catalog,
+      host = credentials$host,
+      port = credentials$port,
+      source = credentials$source,
+      session.timezone = session.timezone,
+      parameters = parameters,
+      extra.credentials = extra.credentials,
+      user = Sys.getenv("USER"),
+      bigint = bigint,
+      ...
+    )
+  } else if (type == "Trino") {
+    conn <- dbConnect(RPresto::Presto(),
+      use.trino.headers = TRUE,
+      schema = "default",
+      catalog = "memory",
+      host = "http://localhost",
+      port = 8090,
+      source = "RPresto_test",
+      session.timezone = session.timezone,
+      parameters = parameters,
+      extra.credentials = extra.credentials,
+      user = Sys.getenv("USER"),
+      bigint = bigint,
+      ...
+    )
+  } else {
+    stop("Connection type is not Presto or Trino.", call. = FALSE)
+  }
   return(conn)
 }
 
@@ -362,7 +382,8 @@ setup_live_dplyr_connection <- function(session.timezone = "",
                                         parameters = list(),
                                         extra.credentials = "",
                                         bigint = c("integer", "integer64", "numeric", "character"),
-                                        ...) {
+                                        ...,
+                                        type = "Presto") {
   skip_on_cran()
 
   credentials <- read_credentials()
@@ -372,7 +393,8 @@ setup_live_dplyr_connection <- function(session.timezone = "",
       parameters,
       extra.credentials,
       bigint,
-      ...
+      ...,
+      type = type
     )
   )
   return(list(db = db, iris_table_name = credentials[["iris_table_name"]]))


### PR DESCRIPTION
Fix the bug (see #176) whereby complex types (ARRAY, MAP, and ROW) and primitive types with timezone are not properly translated into R types in Trino.