### PR TITLE
Allow identifier name to be passed as it is in dbListFields

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # RPresto 1.4.0.9000
 
+* `dbListFields` now works with identifier name which in turn supports the use
+  of `in_schema()` in `tbl()` (#200)
+
 # RPresto 1.4.0
 
 * Change maintainer to Jarod Meng (jarodm@fb.com)

--- a/R/dbListFields.R
+++ b/R/dbListFields.R
@@ -14,8 +14,11 @@ setMethod(
   "dbListFields",
   c("PrestoConnection", "character"),
   function(conn, name, ...) {
-    quoted.name <- DBI::dbQuoteIdentifier(conn, name)
-    res <- dbGetQuery(conn, paste("SHOW COLUMNS FROM", quoted.name))
+    # If name is alrady IDENT, pass it as it is. Otherwise, quote it.
+    if (!dbplyr::is.ident(name)) {
+      name <- DBI::dbQuoteIdentifier(conn, name)
+    }
+    res <- dbGetQuery(conn, paste("SHOW COLUMNS FROM", name))
     return(res$Column)
   }
 )

--- a/tests/testthat/test-dbListFields.R
+++ b/tests/testthat/test-dbListFields.R
@@ -28,6 +28,24 @@ test_that("dbListFields works with live database", {
   expect_true(dbClearResult(result))
 })
 
+test_that("dbListFields works with identifier", {
+  skip_if_not(presto_has_default())
+
+  conn <- DBI::dbConnect(
+    drv = Presto(),
+    host = "http://localhost",
+    port = 8080,
+    user = Sys.getenv("USER"),
+    catalog = "memory",
+    schema = "default"
+  )
+  DBI::dbWriteTable(conn, "iris", iris, overwrite = TRUE)
+  expect_equal(
+    DBI::dbListFields(conn, dbplyr::ident("iris")),
+    tolower(colnames(iris))
+  )
+})
+
 test_that("dbListFields works with mock - PrestoConnection", {
   conn <- setup_mock_connection()
   with_mock(


### PR DESCRIPTION
This fixes #200 to support `in_schema()` in `tbl()` in the same catalog.