### PR TITLE
Modify dbDataType() implementation and a unit tests without changing the main APIs and outputs

### DIFF
--- a/R/dbDataType.R
+++ b/R/dbDataType.R
@@ -7,35 +7,6 @@
 #' @include PrestoDriver.R
 NULL
 
-.presto.to.R <- as.data.frame(matrix(c(
-  "boolean", "logical",
-  "bigint", "integer",
-  "integer", "integer",
-  "smallint", "integer",
-  "tinyint", "integer",
-  "decimal", "character",
-  "real", "numeric",
-  "double", "numeric",
-  "varchar", "character",
-  "char", "character",
-  "varbinary", "raw",
-  "json", "character",
-  "date", "Date",
-  "time", "character",
-  "time with time zone", "character",
-  "timestamp", "POSIXct_no_time_zone",
-  "timestamp with time zone", "POSIXct_with_time_zone",
-  "interval year to month", "character",
-  "interval day to second", "character",
-  "array", "list_unnamed",
-  "map", "list_named",
-  "row", "list_named",
-  "unknown", "unknown"
-), byrow = TRUE, ncol = 2), stringsAsFactors = FALSE)
-colnames(.presto.to.R) <- c("presto.type", "R.type")
-
-
-
 .R.to.presto <- as.data.frame(matrix(c(
   "boolean", "logical",
   "bigint", "integer",

--- a/tests/testthat/test-presto_field.R
+++ b/tests/testthat/test-presto_field.R
@@ -778,13 +778,19 @@ test_that("Queries return the correct map types", {
   # single null row value with single row value is mapped to a list consisting
   # of a NA and a named list
   expect_equal_data_frame(
-    df.row_single_null_and_value <- dbGetQuery(
-      conn,
-      "
-        select cast(null as row(x int)) as type_row_single_null_and_value
-        union all
-        select cast(row(1) as row(x int)) as type_row_single_null_and_value
-      "
+    df.row_single_null_and_value <- dplyr::select(
+      dplyr::arrange(
+        dbGetQuery(
+          conn,
+          "
+            select 0 as row, cast(null as row(x int)) as type_row_single_null_and_value
+            union all
+            select 1 as row, cast(row(1) as row(x int)) as type_row_single_null_and_value
+          "
+        ),
+        row
+      ),
+      -row
     ),
     tibble::tibble(type_row_single_null_and_value = list(NA, list(x = 1)))
   )


### PR DESCRIPTION
This PR is mainly minor improvements of the code implementing dbDataType() without changing the outputs. We will follow up with more significant code improvements (potentially with output changes) in the future.