### PR TITLE
fix typo for `tbl.PrestoConnection()`

### DIFF
--- a/R/dbplyr-src.R
+++ b/R/dbplyr-src.R
@@ -136,7 +136,7 @@ tbl.src_presto <- function(src, from, ..., vars = NULL) {
 
 #' Create a remote database source table using a PrestoConnection
 #'
-#' Automatically create a Presto remote database source to wrap aroudn the
+#' Automatically create a Presto remote database source to wrap around the
 #' `PrestoConnection` object via which DBI APIs can be called.
 #'
 #' @importFrom dplyr tbl


### PR DESCRIPTION
Fixes a typo in the documentation for `tbl.PrestoConnection()`.