### PR TITLE
Make RPresto compatible with new Presto JSON data format and dbplyr 2.5.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Fixed a bug whereby nested CTEs result in nested WITH. (#261)
 * Fixed `paste()` and `paste0()` translation (#266)
-* RPresto is now compatible with dbplyr 2.5.0.
+* RPresto is now compatible with dbplyr 2.5.0 (#272, #274, #277)
 
 # RPresto 1.4.6
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Fixed a bug whereby nested CTEs result in nested WITH. (#261)
 * Fixed `paste()` and `paste0()` translation (#266)
+* RPresto is now compatible with dbplyr 2.5.0.
 
 # RPresto 1.4.6
 

--- a/R/cte.R
+++ b/R/cte.R
@@ -16,7 +16,9 @@ get_tables_from_sql.lazy_select_query <- function(query) {
 #' @export
 get_tables_from_sql.lazy_base_remote_query <- function(query) {
   if (inherits(query$x, "dbplyr_table_path")) { # dbplyr >= 2.5.0
-    utils::getFromNamespace("table_path_name", "dbplyr")(query$x)
+    sim_conn <- dbplyr::simulate_dbi("PrestoConnection")
+    table_name <- dbplyr::table_path_name(query$x, sim_conn)
+    DBI::dbUnquoteIdentifier(sim_conn, table_name)[[1]]@name
   } else if (inherits(query$x, "dbplyr_table_ident")) { # dbplyr >= 2.4.0
     vctrs::field(query$x, "table")
   } else {

--- a/R/dbExistsTable.R
+++ b/R/dbExistsTable.R
@@ -23,8 +23,8 @@ setMethod(
         FROM information_schema.columns
         WHERE
           table_catalog = '", conn@catalog, "' AND
-          table_schema = '", ifelse(!"schema" %in% names(table_name), conn@schema, table_name["schema"]), "' AND
-          table_name = '", table_name["table"], "'
+          table_schema = '", ifelse(length(table_name) == 2L, table_name[1], conn@schema), "' AND
+          table_name = '", table_name[length(table_name)], "'
       ")
     )
     return((res$n > 0))

--- a/R/sqlCreateTableAs.R
+++ b/R/sqlCreateTableAs.R
@@ -31,7 +31,11 @@ setGeneric("sqlCreateTableAs",
 #' @rdname PrestoConnection-class
 #' @usage NULL
 .sqlCreateTableAs <- function(con, name, sql, with = NULL, ...) {
-  name <- DBI::dbQuoteIdentifier(con, name)
+  if (inherits(name, "dbplyr_table_path")) { # dbplyr >= 2.5.0
+    name <- dbplyr::table_path_name(name, con)
+  } else {
+    name <- DBI::dbQuoteIdentifier(con, name)
+  }
 
   DBI::SQL(paste0(
     "CREATE TABLE ", name, "\n",


### PR DESCRIPTION
There have been some changes to Presto and `dbplyr` which result in RPresto 1.4.6 having errors. This PR combines a few commits to solve those issues and make RPresto compatible again.

This PR should fix #272, #274, and #277.