### PR TITLE
`dbWriteTable(overwrite = TRUE)` creates temp table in the destination schema

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 * Fixed a bug whereby nested CTEs result in nested WITH. (#261)
 * Fixed `paste()` and `paste0()` translation (#266)
 * RPresto is now compatible with dbplyr 2.5.0 (#272, #274, #277)
+* `dbWriteTable(overwrite = TRUE)` makes sure that the temp table is created
+  in the same schema as the destination table (#279)
 
 # RPresto 1.4.6
 

--- a/R/cte.R
+++ b/R/cte.R
@@ -18,6 +18,12 @@ get_tables_from_sql.lazy_base_remote_query <- function(query) {
   if (inherits(query$x, "dbplyr_table_path")) { # dbplyr >= 2.5.0
     sim_conn <- dbplyr::simulate_dbi("PrestoConnection")
     table_name <- dbplyr::table_path_name(query$x, sim_conn)
+    if (utils::packageVersion("DBI") < "1.2.0") {
+      stop(
+        "DBI version needs to be >= 1.2.0 to be used with dbplyr >= 2.5.0",
+        call. = FALSE
+      )
+    }
     DBI::dbUnquoteIdentifier(sim_conn, table_name)[[1]]@name
   } else if (inherits(query$x, "dbplyr_table_ident")) { # dbplyr >= 2.4.0
     vctrs::field(query$x, "table")

--- a/R/dbWriteTable.R
+++ b/R/dbWriteTable.R
@@ -94,6 +94,11 @@ NULL
   rn <- paste0(
     "temp_", paste(sample(letters, 10, replace = TRUE), collapse = "")
   )
+  if (inherits(name, "dbplyr_schema")) {
+    name_sql <- DBI::dbQuoteIdentifier(conn, name)
+    name_with_schema <- DBI::dbUnquoteIdentifier(conn, name_sql)[[1]]@name
+    rn <- dbplyr::in_schema(name_with_schema[1], rn)
+  }
   if (found && overwrite) {
     # Without implementation of TRANSACTION, we play it safe by renaming
     # the to-be-overwritten table rather than deleting it right away

--- a/RPresto.Rproj
+++ b/RPresto.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: eb727814-0836-4309-a3c1-778215feb3ca
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/tests/testthat/test-copy_to.src_presto.R
+++ b/tests/testthat/test-copy_to.src_presto.R
@@ -47,6 +47,20 @@ source("utilities.R")
   )
   expect_true(dbExistsTable(con, test_table_name))
   expect_equal_data_frame(collect(tbl), test_df)
+  # a different schema works
+  new_schema_name <- paste0(con@schema, "2")
+  DBI::dbExecute(con, paste0("CREATE SCHEMA IF NOT EXISTS ", new_schema_name))
+  test_table_name_4 <- dbplyr::in_schema(new_schema_name, test_table_name)
+  tbl <- copy_to(dest = src, df = test_df, name = test_table_name_4)
+  expect_true(dbExistsTable(con, test_table_name_4))
+  expect_equal_data_frame(collect(tbl), test_df)
+  # overwriting a different schema works
+  tbl <- copy_to(
+    dest = src, df = test_df, name = test_table_name_4, overwrite = TRUE
+  )
+  expect_true(dbExistsTable(con, test_table_name_4))
+  expect_equal_data_frame(collect(tbl), test_df)
+  expect_true(dbRemoveTable(con, test_table_name_4))
 }
 
 test_that("dplyr::copy_to works for src_presto", {


### PR DESCRIPTION
Also make sure that DBI >= 1.2.0 is used with dbplyr >= 2.5.0.